### PR TITLE
test: add unit tests for mcp and services modules

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -60,8 +60,8 @@ test('initCommand copies expected templates with replacements', async () => {
   const cwd = '/tmp/project';
   await initCommand({ cwd, endpoint: DEFAULT_ENDPOINT, group: DEFAULT_GROUP, force: true }, services);
 
-  // Expect 2 skill files + 2 docker assets = 4 copies.
-  assert.equal(services.templateCopier.calls.length, 4);
+  // Expect: 2 skills + 3 shared rules + 3 typescript rules + 3 claude files + 2 docker assets = 13 copies.
+  assert.equal(services.templateCopier.calls.length, 13);
   const memoryCopy = services.templateCopier.calls.find((c) => c.dest.endsWith(path.join('.agents', 'skills', 'memory', 'SKILL.md')));
   assert.ok(memoryCopy, 'memory SKILL should be copied');
   assert.equal(memoryCopy?.replacements.GRAPHITI_ENDPOINT, DEFAULT_ENDPOINT);
@@ -73,8 +73,8 @@ test('initCommand skips docker assets when includeDocker is false', async () => 
   const cwd = '/tmp/project';
   await initCommand({ cwd, endpoint: DEFAULT_ENDPOINT, group: DEFAULT_GROUP, force: true, includeDocker: false }, services);
 
-  // Expect 2 skill files only.
-  assert.equal(services.templateCopier.calls.length, 2);
+  // Expect: 2 skills + 3 shared rules + 3 typescript rules + 3 claude files = 11 copies (no docker).
+  assert.equal(services.templateCopier.calls.length, 11);
   assert.ok(!services.templateCopier.calls.find((c) => c.dest.endsWith('docker-compose.graphiti.yml')));
 });
 

--- a/src/lib/mcp.test.ts
+++ b/src/lib/mcp.test.ts
@@ -1,0 +1,124 @@
+import { test, mock, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { pingMcp } from './mcp';
+
+// Store original fetch
+const originalFetch = globalThis.fetch;
+
+// Mock response factory
+function createMockResponse(options: {
+  ok?: boolean;
+  status?: number;
+  headers?: Record<string, string>;
+}): Response {
+  const { ok = true, status = 200, headers = {} } = options;
+  return {
+    ok,
+    status,
+    headers: {
+      get: (name: string) => headers[name.toLowerCase()] || null,
+    },
+  } as unknown as Response;
+}
+
+beforeEach(() => {
+  // Reset fetch mock before each test
+  globalThis.fetch = mock.fn();
+});
+
+afterEach(() => {
+  // Restore original fetch after each test
+  globalThis.fetch = originalFetch;
+});
+
+test('pingMcp should succeed when server returns valid response with session id', async () => {
+  // Arrange
+  const endpoint = 'http://localhost:8010/mcp/';
+  const mockFetch = mock.fn(async () =>
+    createMockResponse({
+      ok: true,
+      status: 200,
+      headers: { 'mcp-session-id': 'test-session-123' },
+    })
+  );
+  globalThis.fetch = mockFetch;
+
+  // Act & Assert - should not throw
+  await pingMcp(endpoint);
+
+  // Verify fetch was called correctly
+  assert.equal(mockFetch.mock.calls.length, 1);
+  const [callUrl, callOptions] = mockFetch.mock.calls[0].arguments;
+  assert.equal(callUrl, endpoint);
+  assert.equal(callOptions.method, 'POST');
+  assert.equal(callOptions.headers['Content-Type'], 'application/json');
+
+  // Verify request body contains required MCP fields
+  const body = JSON.parse(callOptions.body);
+  assert.equal(body.jsonrpc, '2.0');
+  assert.equal(body.method, 'initialize');
+  assert.ok(body.params.protocolVersion);
+  assert.ok(body.params.clientInfo.name);
+});
+
+test('pingMcp should throw error when HTTP response is not ok', async () => {
+  // Arrange
+  const endpoint = 'http://localhost:8010/mcp/';
+  const mockFetch = mock.fn(async () =>
+    createMockResponse({
+      ok: false,
+      status: 500,
+      headers: {},
+    })
+  );
+  globalThis.fetch = mockFetch;
+
+  // Act & Assert
+  await assert.rejects(
+    async () => pingMcp(endpoint),
+    (error: Error) => {
+      assert.match(error.message, /HTTP 500/);
+      return true;
+    }
+  );
+});
+
+test('pingMcp should throw error when mcp-session-id header is missing', async () => {
+  // Arrange
+  const endpoint = 'http://localhost:8010/mcp/';
+  const mockFetch = mock.fn(async () =>
+    createMockResponse({
+      ok: true,
+      status: 200,
+      headers: {}, // No mcp-session-id
+    })
+  );
+  globalThis.fetch = mockFetch;
+
+  // Act & Assert
+  await assert.rejects(
+    async () => pingMcp(endpoint),
+    (error: Error) => {
+      assert.match(error.message, /mcp-session-id/i);
+      return true;
+    }
+  );
+});
+
+test('pingMcp should throw error when fetch fails', async () => {
+  // Arrange
+  const endpoint = 'http://localhost:8010/mcp/';
+  const mockFetch = mock.fn(async () => {
+    throw new Error('Network error');
+  });
+  globalThis.fetch = mockFetch;
+
+  // Act & Assert
+  await assert.rejects(
+    async () => pingMcp(endpoint),
+    (error: Error) => {
+      assert.match(error.message, /Network error/);
+      return true;
+    }
+  );
+});

--- a/src/lib/services.test.ts
+++ b/src/lib/services.test.ts
@@ -1,0 +1,152 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs-extra';
+import path from 'path';
+import os from 'os';
+import { createDefaultServices } from './services';
+
+let tempDir: string;
+let templateDir: string;
+let destDir: string;
+
+beforeEach(async () => {
+  // Create temp directories for each test
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'lisa-test-'));
+  templateDir = path.join(tempDir, 'templates');
+  destDir = path.join(tempDir, 'dest');
+  await fs.ensureDir(templateDir);
+  await fs.ensureDir(destDir);
+});
+
+afterEach(async () => {
+  // Clean up temp directories
+  await fs.remove(tempDir);
+});
+
+test('DefaultTemplateCopier copies file with replacements', async () => {
+  // Arrange
+  const templateContent = 'Hello {{NAME}}, welcome to {{PROJECT}}!';
+  const templateFile = 'greeting.txt';
+  await fs.writeFile(path.join(templateDir, templateFile), templateContent);
+
+  const services = createDefaultServices(templateDir);
+  const destPath = path.join(destDir, 'output.txt');
+  const replacements = { NAME: 'Alice', PROJECT: 'Lisa' };
+
+  // Act
+  const result = await services.templateCopier.copy(templateFile, destPath, replacements);
+
+  // Assert
+  assert.equal(result.skipped, false);
+  const outputContent = await fs.readFile(destPath, 'utf8');
+  assert.equal(outputContent, 'Hello Alice, welcome to Lisa!');
+});
+
+test('DefaultTemplateCopier skips existing file when force is false', async () => {
+  // Arrange
+  const templateContent = 'New content';
+  const templateFile = 'file.txt';
+  await fs.writeFile(path.join(templateDir, templateFile), templateContent);
+
+  const destPath = path.join(destDir, 'existing.txt');
+  const existingContent = 'Existing content';
+  await fs.writeFile(destPath, existingContent);
+
+  const services = createDefaultServices(templateDir);
+
+  // Act
+  const result = await services.templateCopier.copy(templateFile, destPath, {}, false);
+
+  // Assert
+  assert.equal(result.skipped, true);
+  const outputContent = await fs.readFile(destPath, 'utf8');
+  assert.equal(outputContent, existingContent); // Should not be overwritten
+});
+
+test('DefaultTemplateCopier overwrites existing file when force is true', async () => {
+  // Arrange
+  const templateContent = 'New content from {{SOURCE}}';
+  const templateFile = 'file.txt';
+  await fs.writeFile(path.join(templateDir, templateFile), templateContent);
+
+  const destPath = path.join(destDir, 'existing.txt');
+  await fs.writeFile(destPath, 'Old content');
+
+  const services = createDefaultServices(templateDir);
+
+  // Act
+  const result = await services.templateCopier.copy(templateFile, destPath, { SOURCE: 'template' }, true);
+
+  // Assert
+  assert.equal(result.skipped, false);
+  const outputContent = await fs.readFile(destPath, 'utf8');
+  assert.equal(outputContent, 'New content from template');
+});
+
+test('DefaultTemplateCopier throws error for missing template', async () => {
+  // Arrange
+  const services = createDefaultServices(templateDir);
+  const destPath = path.join(destDir, 'output.txt');
+
+  // Act & Assert
+  await assert.rejects(
+    async () => services.templateCopier.copy('nonexistent.txt', destPath, {}),
+    (error: Error) => {
+      assert.match(error.message, /Missing template/);
+      return true;
+    }
+  );
+});
+
+test('DefaultTemplateCopier creates parent directories if they do not exist', async () => {
+  // Arrange
+  const templateContent = 'Content';
+  const templateFile = 'file.txt';
+  await fs.writeFile(path.join(templateDir, templateFile), templateContent);
+
+  const services = createDefaultServices(templateDir);
+  const destPath = path.join(destDir, 'nested', 'deep', 'output.txt');
+
+  // Act
+  const result = await services.templateCopier.copy(templateFile, destPath, {});
+
+  // Assert
+  assert.equal(result.skipped, false);
+  assert.ok(await fs.pathExists(destPath));
+  const outputContent = await fs.readFile(destPath, 'utf8');
+  assert.equal(outputContent, 'Content');
+});
+
+test('DefaultTemplateCopier handles multiple occurrences of same placeholder', async () => {
+  // Arrange
+  const templateContent = '{{VAR}} and {{VAR}} and {{VAR}}';
+  const templateFile = 'multi.txt';
+  await fs.writeFile(path.join(templateDir, templateFile), templateContent);
+
+  const services = createDefaultServices(templateDir);
+  const destPath = path.join(destDir, 'output.txt');
+
+  // Act
+  await services.templateCopier.copy(templateFile, destPath, { VAR: 'X' });
+
+  // Assert
+  const outputContent = await fs.readFile(destPath, 'utf8');
+  assert.equal(outputContent, 'X and X and X');
+});
+
+test('DefaultTemplateCopier preserves content with no placeholders', async () => {
+  // Arrange
+  const templateContent = 'Plain text with no placeholders';
+  const templateFile = 'plain.txt';
+  await fs.writeFile(path.join(templateDir, templateFile), templateContent);
+
+  const services = createDefaultServices(templateDir);
+  const destPath = path.join(destDir, 'output.txt');
+
+  // Act
+  await services.templateCopier.copy(templateFile, destPath, { UNUSED: 'value' });
+
+  // Assert
+  const outputContent = await fs.readFile(destPath, 'utf8');
+  assert.equal(outputContent, templateContent);
+});


### PR DESCRIPTION
Add comprehensive unit tests following project testing standards:
- mcp.test.ts: Tests for pingMcp function covering success, HTTP errors, missing headers, and network failures
- services.test.ts: Tests for DefaultTemplateCopier covering file copying, replacements, force mode, missing templates, and directory creation
- Update cli.test.ts assertions to match current template count (13 with Docker, 11 without)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for template copying with updated copy count expectations.
  * Added new test suite for MCP ping functionality, covering success, HTTP errors, missing headers, and network failures.
  * Added new test module for template copying service behavior, including replacements, overwrites, and error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->