### PR TITLE
fix(tasks): write tasks directly to Neo4j instead of MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.6.2] - 2026-01-27
+
+### Fixed
+
+#### Task Writes Now Go Directly to Neo4j ([#48](https://github.com/TonyCasey/lisa/issues/48))
+
+Task operations now write directly to Neo4j instead of going through MCP's async queue, ensuring tasks appear immediately in `lisa tasks list`.
+
+**Problem**: Tasks added via `lisa tasks add` were queued through MCP/Graphiti but never appeared in Neo4j due to silent processing failures.
+
+**Solution**: Changed `TaskService` to write directly to Neo4j:
+- `add()` - Creates Episodic node directly in Neo4j (was already fixed)
+- `update()` - Now creates Episodic node directly instead of using MCP
+- `link()` - Now creates Episodic node directly instead of using MCP  
+- `unlink()` - Now creates Episodic node directly instead of using MCP
+
+**Impact**: 
+- Tasks appear immediately after creation
+- Task updates are reflected instantly
+- External link changes persist immediately
+- Consistent read/write path (both use Neo4j)
+
+### Changed
+
+- `ITaskLinkResult.mode` now includes `'neo4j'` as a valid value
+
+---
+
 ## [2.6.1] - 2026-01-27
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonycasey/lisa",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Long-term memory for AI coding assistants. Automatic context persistence, task tracking, and knowledge capture across coding sessions. Supports Claude Code and OpenCode.",
   "bin": {
     "lisa": "dist/lib/cli.js",

--- a/src/lib/skills/shared/services/TaskService.ts
+++ b/src/lib/skills/shared/services/TaskService.ts
@@ -242,25 +242,40 @@ export function createTaskService(deps: ITaskServiceDependencies): ITaskService 
         };
       }
 
-      // Use MCP
-      await mcpClient.initialize();
-      const params = {
-        name: `TASK UPDATE: ${title.slice(0, 60)}`,
-        episode_body: JSON.stringify({ ...storageObj, updated: true }),
-        source: 'json',
-        group_id: groupId,
-        tags: options.tag ? [options.tag] : undefined,
-      };
-      const result = await mcpClient.rpcCall<unknown>('add_memory', params);
+      // Write directly to Neo4j for immediate persistence
+      // Update creates a new episodic node (append-only pattern)
+      const uuid = `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+      const name = `TASK: ${title.slice(0, 60)}`;
+      const content = JSON.stringify({ ...storageObj, updated: true });
+      const createdAt = new Date().toISOString();
 
-      return {
-        status: 'ok',
-        action: 'update',
-        task: taskObj,
-        group: groupId,
-        result,
-        mode: 'mcp',
-      };
+      await neo4jClient.connect();
+      try {
+        const cypher = `
+          CREATE (e:Episodic {
+            uuid: $uuid,
+            name: $name,
+            content: $content,
+            group_id: $groupId,
+            created_at: datetime($createdAt),
+            source: 'lisa-cli',
+            source_description: 'Task updated via lisa tasks update'
+          })
+          RETURN e.uuid AS uuid
+        `;
+        await neo4jClient.query(cypher, { uuid, name, content, groupId, createdAt });
+
+        return {
+          status: 'ok',
+          action: 'update',
+          task: taskObj,
+          group: groupId,
+          result: { uuid, message: `Task updated with uuid ${uuid}` },
+          mode: 'neo4j',
+        };
+      } finally {
+        await neo4jClient.disconnect();
+      }
     },
 
     async link(
@@ -319,15 +334,26 @@ export function createTaskService(deps: ITaskServiceDependencies): ITaskService 
           };
         }
 
-        // Use MCP
-        await mcpClient.initialize();
-        const params = {
-          name: `TASK LINK: ${String(taskObj.title).slice(0, 50)} -> ${externalLink.source}#${externalLink.id}`,
-          episode_body: JSON.stringify({ ...taskObj, linked: true }),
-          source: 'json',
-          group_id: groupId,
-        };
-        await mcpClient.rpcCall<unknown>('add_memory', params);
+        // Write directly to Neo4j for immediate persistence
+        // Link creates a new episodic node with the updated link info
+        const newUuid = `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+        const name = `TASK: ${String(taskObj.title).slice(0, 60)}`;
+        const content = JSON.stringify({ ...taskObj, linked: true });
+        const createdAt = new Date().toISOString();
+
+        const createCypher = `
+          CREATE (e:Episodic {
+            uuid: $uuid,
+            name: $name,
+            content: $content,
+            group_id: $groupId,
+            created_at: datetime($createdAt),
+            source: 'lisa-cli',
+            source_description: 'Task linked via lisa tasks link'
+          })
+          RETURN e.uuid AS uuid
+        `;
+        await neo4jClient.query(createCypher, { uuid: newUuid, name, content, groupId, createdAt });
 
         return {
           status: 'ok',
@@ -338,7 +364,7 @@ export function createTaskService(deps: ITaskServiceDependencies): ITaskService 
             externalLink: taskObj.externalLink as ITaskExternalLink,
           },
           group: groupId,
-          mode: 'mcp',
+          mode: 'neo4j',
         };
       } finally {
         await neo4jClient.disconnect();
@@ -395,15 +421,26 @@ export function createTaskService(deps: ITaskServiceDependencies): ITaskService 
           };
         }
 
-        // Use MCP
-        await mcpClient.initialize();
-        const params = {
-          name: `TASK UNLINK: ${String(taskObj.title).slice(0, 60)}`,
-          episode_body: JSON.stringify({ ...taskObj, unlinked: true }),
-          source: 'json',
-          group_id: groupId,
-        };
-        await mcpClient.rpcCall<unknown>('add_memory', params);
+        // Write directly to Neo4j for immediate persistence
+        // Unlink creates a new episodic node with the link removed
+        const newUuid = `task-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+        const name = `TASK: ${String(taskObj.title).slice(0, 60)}`;
+        const content = JSON.stringify({ ...taskObj, unlinked: true });
+        const createdAt = new Date().toISOString();
+
+        const createCypher = `
+          CREATE (e:Episodic {
+            uuid: $uuid,
+            name: $name,
+            content: $content,
+            group_id: $groupId,
+            created_at: datetime($createdAt),
+            source: 'lisa-cli',
+            source_description: 'Task unlinked via lisa tasks unlink'
+          })
+          RETURN e.uuid AS uuid
+        `;
+        await neo4jClient.query(createCypher, { uuid: newUuid, name, content, groupId, createdAt });
 
         return {
           status: 'ok',
@@ -413,7 +450,7 @@ export function createTaskService(deps: ITaskServiceDependencies): ITaskService 
             uuid: taskUuid,
           },
           group: groupId,
-          mode: 'mcp',
+          mode: 'neo4j',
         };
       } finally {
         await neo4jClient.disconnect();

--- a/src/lib/skills/shared/services/interfaces/ITaskService.ts
+++ b/src/lib/skills/shared/services/interfaces/ITaskService.ts
@@ -99,7 +99,7 @@ export interface ITaskLinkResult {
     externalLink?: ITaskExternalLink;
   };
   group: string;
-  mode: 'mcp' | 'zep-cloud';
+  mode: 'mcp' | 'zep-cloud' | 'neo4j';
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #48 - Task writes should go directly to Neo4j, not MCP

Task operations now write directly to Neo4j instead of going through MCP's async queue, ensuring tasks appear immediately.

## Problem

`lisa tasks add` was writing tasks via MCP's `add_memory` endpoint, which queued episodes for async processing by Graphiti. This caused:
1. Tasks didn't appear immediately - they were queued but not persisted
2. Graphiti processing failed silently ("Successfully processed episode None")
3. Inconsistent behavior - reads used Neo4j, but writes went through MCP

## Solution

Changed `TaskService` to write directly to Neo4j:

| Method | Before | After |
|--------|--------|-------|
| `add()` | Neo4j (already fixed) | Neo4j |
| `update()` | MCP async queue | Neo4j direct |
| `link()` | MCP async queue | Neo4j direct |
| `unlink()` | MCP async queue | Neo4j direct |

## Changes

- `src/lib/skills/shared/services/TaskService.ts` - Write directly to Neo4j for update/link/unlink
- `src/lib/skills/shared/services/interfaces/ITaskService.ts` - Added 'neo4j' to ITaskLinkResult.mode

## Testing

- All 497 unit tests pass
- Build succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Task operations to write directly to Neo4j database, bypassing the MCP queue for improved reliability and consistency.

* **Changed**
  * Task link results now support Neo4j as a persistence mode alongside existing options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->