### PR TITLE
feat(pr): add auto-address to poll command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+#### Auto-Address Flag for PR Poll ([#64](https://github.com/TonyCasey/lisa/issues/64))
+
+The `lisa pr poll` command now automatically outputs formatted instructions for addressing new comments when detected. This is enabled by default.
+
+**Usage:**
+```bash
+lisa pr poll                # Auto-address enabled (default)
+lisa pr poll --no-auto-address  # Disable auto-address
+```
+
+When new comments are detected on watched PRs, the poll command will automatically call `lisa pr address` and output the formatted comment details with instructions for addressing them.
+
+---
+
 ## [2.11.0] - 2026-01-27
 
 ### Added

--- a/src/lib/application/handlers/pr/PrPollHandler.ts
+++ b/src/lib/application/handlers/pr/PrPollHandler.ts
@@ -26,6 +26,7 @@ import type { IGhCheckResponse, IGhReviewCommentResponse } from '../../../infras
 import { GithubClientError } from '../../../infrastructure/github/types';
 import type { INotificationService, INotification } from '../../../domain/interfaces/INotificationService';
 import { createNotificationFromStateChange } from '../../../infrastructure/notifications/NotificationService';
+import { PrAddressHandler } from './PrAddressHandler';
 
 /**
  * State change detected during polling.
@@ -78,6 +79,17 @@ export interface IPrPollResult {
   readonly totalErrors: number;
   readonly items: readonly IPrPollItem[];
   readonly logPath?: string;
+  /** Auto-address output for PRs with new comments (when autoAddress is enabled) */
+  readonly addressOutput?: readonly IAutoAddressOutput[];
+}
+
+/**
+ * Auto-address output for a single PR.
+ */
+export interface IAutoAddressOutput {
+  readonly prNumber: number;
+  readonly repo: string;
+  readonly formattedOutput: string;
 }
 
 /**
@@ -92,6 +104,8 @@ export interface IPrPollOptions {
   readonly concurrency?: number;
   /** Send desktop notifications for state changes (default: false) */
   readonly notify?: boolean;
+  /** Auto-address new comments by outputting formatted instructions (default: true) */
+  readonly autoAddress?: boolean;
 }
 
 /**
@@ -116,6 +130,7 @@ export class PrPollHandler {
     const autoUnwatch = options?.autoUnwatch ?? true;
     const logToFile = options?.logToFile ?? true;
     const notify = options?.notify ?? false;
+    const autoAddress = options?.autoAddress ?? true;
     // Guard against zero/negative concurrency to prevent infinite loops
     const concurrency = Math.max(1, options?.concurrency ?? 5);
 
@@ -178,6 +193,40 @@ export class PrPollHandler {
         log(`Sent ${notifications.length} desktop notification(s).`);
       }
 
+      // Auto-address PRs with new comments
+      let addressOutput: IAutoAddressOutput[] | undefined;
+      if (autoAddress) {
+        const prsWithNewComments = pollResults.filter(item =>
+          item.changes.some(c => c.type === 'new_comment' || c.type === 'new_reply')
+        );
+
+        if (prsWithNewComments.length > 0) {
+          addressOutput = [];
+          const addressHandler = new PrAddressHandler(this.githubClient, this.prRepository);
+
+          for (const item of prsWithNewComments) {
+            try {
+              const addressResult = await addressHandler.execute({
+                repo: item.repo,
+                prNumber: item.number,
+              });
+
+              if (addressResult.commentsToAddress.length > 0) {
+                addressOutput.push({
+                  prNumber: item.number,
+                  repo: item.repo,
+                  formattedOutput: addressResult.formattedOutput,
+                });
+                log(`Auto-address: ${item.repo}#${item.number} has ${addressResult.commentsToAddress.length} comment(s) to address`);
+              }
+            } catch (err) {
+              const errMsg = err instanceof Error ? err.message : String(err);
+              log(`Auto-address failed for ${item.repo}#${item.number}: ${errMsg}`);
+            }
+          }
+        }
+      }
+
       log(`Poll complete. ${totalChanges} notification(s).`);
 
       // Write to log file
@@ -198,6 +247,7 @@ export class PrPollHandler {
         totalErrors,
         items: pollResults,
         logPath,
+        addressOutput: addressOutput && addressOutput.length > 0 ? addressOutput : undefined,
       };
     } catch (error) {
       const message = this.getErrorMessage(error);

--- a/src/lib/application/handlers/pr/index.ts
+++ b/src/lib/application/handlers/pr/index.ts
@@ -18,5 +18,5 @@ export { PrChecksHandler, type IPrChecksResult } from './PrChecksHandler';
 export { PrCommentsHandler, type IPrCommentsResult } from './PrCommentsHandler';
 export { PrAddressHandler, type IPrAddressResult, type IPrAddressOptions, type ICommentToAddress, type CommentType } from './PrAddressHandler';
 export { PrWatchHandler, type IPrWatchResult } from './PrWatchHandler';
-export { PrPollHandler, type IPrPollResult, type IPrPollOptions, type IPrPollItem, type IStateChange } from './PrPollHandler';
+export { PrPollHandler, type IPrPollResult, type IPrPollOptions, type IPrPollItem, type IStateChange, type IAutoAddressOutput } from './PrPollHandler';
 export { PrStatusHandler, type IPrStatusResult, type IPrStatusOptions, type IPrStatusItem, type IPrsByRepo, type IPrStatusSummary, type ReadyState } from './PrStatusHandler';

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -1253,6 +1253,7 @@ prCmd
   .option('--no-log', 'Do not write to log file')
   .option('-c, --concurrency <n>', 'Max concurrent GitHub API calls', '5')
   .option('--notify', 'Send desktop notifications for state changes')
+  .option('--no-auto-address', 'Do not auto-address new comments')
   .option('--json', 'Output as JSON')
   .action(async (opts) => {
     await withCorrelation(async () => {
@@ -1278,6 +1279,7 @@ prCmd
           logToFile: opts.log,
           concurrency: Number.isFinite(parsedConcurrency) ? parsedConcurrency : 5,
           notify: opts.notify,
+          autoAddress: opts.autoAddress,
         });
 
         if (opts.json) {
@@ -1306,6 +1308,16 @@ prCmd
           if (result.logPath) {
             console.log('');
             console.log(chalk.dim(`Log: ${result.logPath}`));
+          }
+
+          // Display auto-address output if available
+          if (result.addressOutput && result.addressOutput.length > 0) {
+            console.log('');
+            console.log(chalk.bold.cyan('--- Auto-Address Output ---'));
+            for (const addr of result.addressOutput) {
+              console.log('');
+              console.log(addr.formattedOutput);
+            }
           }
         }
 


### PR DESCRIPTION
## Summary
- Add auto-address feature to `lisa pr poll` that automatically outputs formatted instructions when new comments are detected
- Enabled by default, can be disabled with `--no-auto-address`
- When new comments detected, calls `PrAddressHandler` for affected PRs and outputs the formatted comment details

## Usage
```bash
lisa pr poll                    # Auto-address enabled (default)
lisa pr poll --no-auto-address  # Disable auto-address
```

## Changes
- Add `autoAddress` option to `IPrPollOptions` (default: `true`)
- Add `--no-auto-address` CLI flag
- Add `IAutoAddressOutput` interface and `addressOutput` to poll result
- Display auto-address output in CLI when new comments detected

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-address functionality for PR polling now enabled by default, automatically generating formatted instructions when new comments are detected on watched pull requests.
  * New CLI flag `--no-auto-address` to disable auto-addressing during polling.
  * Auto-address output is displayed in poll results.

* **Documentation**
  * Added changelog entry documenting the auto-address feature and usage examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->