### PR TITLE
fix: add github:pr tag to merged PR memories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonycasey/lisa",
-  "version": "2.11.3",
+  "version": "2.11.4",
   "description": "Long-term memory for AI coding assistants. Automatic context persistence, task tracking, and knowledge capture across coding sessions. Supports Claude Code and OpenCode.",
   "bin": {
     "lisa": "dist/lib/cli.js",

--- a/src/lib/application/handlers/pr/PrPollHandler.ts
+++ b/src/lib/application/handlers/pr/PrPollHandler.ts
@@ -339,7 +339,7 @@ export class PrPollHandler {
           if (this.memoryService && this.groupId) {
             try {
               const fact = `PR MERGED: #${pr.number} ${ghPr.title}`;
-              const tags = ['github:pr-merged', `github:pr:${pr.number}`];
+              const tags = ['github:pr', 'github:pr-merged', `github:pr:${pr.number}`];
               await this.memoryService.addFact(this.groupId, fact, tags);
               log(`${pr.repo}#${pr.number}: saved to memory`);
             } catch (memError) {


### PR DESCRIPTION
## Summary

- Added missing `github:pr` tag to merged PR memories in PrPollHandler
- Ensures merged PRs appear in generic PR searches alongside `github:pr-merged` and `github:pr:<number>` tags

## Changes

- `PrPollHandler.ts`: Added `github:pr` to tags array for merged PR memory entries

## Test Plan

- [x] Build succeeds
- [x] All 26 PrPollHandler tests pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released patch version 2.11.4
  * Enhanced pull request tracking with improved categorization tags for better organization and visibility of merged pull request events, enabling more effective system monitoring and operational oversight

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->