### PR TITLE
docs: fix SKILL.md - merge auto-capture not gated by --notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonycasey/lisa",
-  "version": "2.11.4",
+  "version": "2.11.5",
   "description": "Long-term memory for AI coding assistants. Automatic context persistence, task tracking, and knowledge capture across coding sessions. Supports Claude Code and OpenCode.",
   "bin": {
     "lisa": "dist/lib/cli.js",

--- a/src/project/.lisa/skills/pr/SKILL.md
+++ b/src/project/.lisa/skills/pr/SKILL.md
@@ -199,7 +199,7 @@ lisa pr remember 50 "Important learning" --json
 PR workflow integrates with Lisa's memory system for automatic knowledge capture:
 
 **Auto-capture on merge:**
-When a watched PR is merged, it is automatically saved to memory with the `github:pr-merged` tag. This happens during `lisa pr poll --notify` when the PR status changes to merged.
+When a watched PR is merged, it is automatically saved to memory with the `github:pr-merged` tag. This happens during `lisa pr poll` when the PR status changes to merged (requires memory to be configured).
 
 **Retrieve PR memories:**
 ```bash


### PR DESCRIPTION
## Summary

- Fixed documentation that incorrectly stated `--notify` flag was required for merge auto-capture
- Auto-capture happens during any `lisa pr poll` when memory is configured

## Changes

- `src/project/.lisa/skills/pr/SKILL.md`: Updated auto-capture description

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Version bump to 2.11.5

* **Documentation**
  * Clarified Memory Integration documentation regarding the trigger timing for automatic PR merge capture and its configuration requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->