### PR TITLE
bug: group-id logic inconsistent; should be canonical full folder path normalized

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -471,7 +471,7 @@ Address Lisa directly for memory and tasks:
 
 ### Configuration
 - **Endpoint**: `GRAPHITI_ENDPOINT` env or `http://localhost:8010/mcp/`
-- **Group**: `GRAPHITI_GROUP_ID` env or project name
+- **Group**: Automatically derived from project folder path
 - **Storage modes**: Local Docker or Zep Cloud
 
 ### Cross-Model Compatibility

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,6 @@ Lisa can be configured through environment variables and configuration files.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GRAPHITI_ENDPOINT` | `http://localhost:8010/mcp/` | MCP server endpoint |
-| `GRAPHITI_GROUP_ID` | Project folder name | Group ID for organizing memories |
 | `LOG_LEVEL` | `debug` | Logging level: `debug`, `info`, `warn`, `error`, `silent` |
 | `STORAGE_MODE` | `local` | Storage mode: `local`, `neo4j`, `zep-cloud` |
 
@@ -61,9 +60,6 @@ NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=demodemo
 NEO4J_DATABASE=neo4j
-
-# Group ID (optional - defaults to folder name)
-# GRAPHITI_GROUP_ID=my-project
 
 # Zep Cloud (if using)
 # ZEP_API_KEY=your-api-key
@@ -127,24 +123,13 @@ OPENAI_API_KEY=your-openai-key
 
 ## Group IDs
 
-The `GRAPHITI_GROUP_ID` determines how memories are organized:
+Lisa automatically derives the group ID from your project's folder path. This ensures:
 
-- **Per-project** (default): Each project has its own memory namespace
-- **Shared**: Use the same group ID across projects to share memories
-- **Hierarchical**: Lisa automatically queries parent folders for inherited context
+- **Per-project isolation**: Each project has its own memory namespace based on the folder path
+- **Hierarchical context**: Lisa automatically queries parent folders for inherited context
+- **Consistent organization**: Memories are organized by project location, not manual configuration
 
-### Examples
-
-```bash
-# Project-specific (default)
-lisa init -g my-project
-
-# Shared across projects
-lisa init -g company-standards
-
-# Per-user
-lisa init -g ${USER}-personal
-```
+The group ID is automatically set to the project folder path (e.g., `/home/user/projects/my-app` or `C:\Users\user\projects\my-app`). This provides natural project isolation while allowing hierarchical memory inheritance from parent directories.
 
 ## Deployment Modes
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -219,9 +219,10 @@ Skills read configuration from `.lisa/.env`:
 
 ```env
 GRAPHITI_ENDPOINT=http://localhost:8010/mcp/
-GRAPHITI_GROUP_ID=my-project
 LOG_LEVEL=debug
 ```
+
+Note: The group ID is automatically derived from the project folder path and does not need to be configured manually.
 
 ## Creating Custom Skills
 

--- a/mcp_server/config/config-docker-neo4j.yaml
+++ b/mcp_server/config/config-docker-neo4j.yaml
@@ -79,6 +79,7 @@ database:
       use_parallel_runtime: ${USE_PARALLEL_RUNTIME:false}
 
 graphiti:
+  # Server-side fallback only. Clients derive group_id from the project folder path.
   group_id: ${GRAPHITI_GROUP_ID:main}
   episode_id_prefix: ${EPISODE_ID_PREFIX:}
   user_id: ${USER_ID:mcp_user}

--- a/src/lib/cli.ts
+++ b/src/lib/cli.ts
@@ -417,7 +417,7 @@ memoryCmd
     const args = ['load'];
     if (opts.group) args.push('--group', opts.group);
     if (opts.query) args.push('--query', opts.query);
-    if (opts.limit) args.push('--limit', opts.limit);
+    if (opts.limit) args.push('--limit', String(parseInt(opts.limit, 10)));
     if (opts.since) args.push('--since', opts.since);
     if (opts.until) args.push('--until', opts.until);
     if (opts.cache) args.push('--cache');
@@ -460,7 +460,7 @@ tasksCmd
   .action(async (opts) => {
     const args = ['list'];
     if (opts.group) args.push('--group', opts.group);
-    if (opts.limit) args.push('--limit', opts.limit);
+    if (opts.limit) args.push('--limit', String(parseInt(opts.limit, 10)));
     if (opts.since) args.push('--since', opts.since);
     if (opts.until) args.push('--until', opts.until);
     if (opts.cache) args.push('--cache');

--- a/src/lib/commands/doctor.ts
+++ b/src/lib/commands/doctor.ts
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import chalk from 'chalk';
 import type { IServices } from '../interfaces/IServices';
+import { getCurrentGroupId } from '../skills/shared/utils/group-id';
 
 // ============================================================================
 // Types
@@ -96,7 +97,6 @@ type DeploymentMode = 'local' | 'zep-cloud' | 'skip';
 
 interface ILoadedConfig {
   endpoint?: string;
-  group?: string;
   mode?: DeploymentMode;
   zepApiKey?: string;
   zepProjectId?: string;
@@ -126,7 +126,6 @@ async function loadConfig(cwd: string): Promise<ILoadedConfig | null> {
 
   return {
     endpoint: map.GRAPHITI_ENDPOINT,
-    group: map.GRAPHITI_GROUP_ID,
     mode: map.STORAGE_MODE as DeploymentMode | undefined,
     zepApiKey: map.ZEP_API_KEY,
     zepProjectId: map.ZEP_PROJECT_ID,
@@ -553,7 +552,7 @@ export async function runDoctor(
     opts.endpoint ||
     config?.endpoint ||
     (mode === 'zep-cloud' ? ZEP_CLOUD_ENDPOINT : DEFAULT_ENDPOINT);
-  const group = config?.group || projectName;
+  const group = getCurrentGroupId(cwd);
   const zepApiKey = config?.zepApiKey || process.env.ZEP_API_KEY;
 
   // Build config info

--- a/src/lib/commands/init.ts
+++ b/src/lib/commands/init.ts
@@ -16,7 +16,6 @@ import {
   BUNDLED_OPENCODE_ROOT,
   DEFAULT_ENDPOINT,
   ZEP_CLOUD_ENDPOINT,
-  DEFAULT_GROUP,
   type DeploymentMode,
   type CliSupport,
   type IGraphitiConfig,
@@ -198,14 +197,6 @@ async function promptZepCloudConfig(): Promise<Partial<IGraphitiConfig>> {
   });
 
   return { zepApiKey, zepProjectId, endpoint: ZEP_CLOUD_ENDPOINT };
-}
-
-async function promptGroupId(): Promise<string> {
-  const projectName = path.basename(process.cwd());
-  return await input({
-    message: 'Group ID:',
-    default: projectName,
-  });
 }
 
 async function promptCliSupport(): Promise<CliSupport[]> {
@@ -416,7 +407,6 @@ export async function initCommand(opts: IInitOptions, services: IServices): Prom
     config = {
       mode,
       endpoint: opts.endpoint || (mode === 'zep-cloud' ? ZEP_CLOUD_ENDPOINT : DEFAULT_ENDPOINT),
-      groupId: opts.group || process.env.GRAPHITI_GROUP_ID || DEFAULT_GROUP,
       zepApiKey: opts.zepApiKey,
       zepProjectId: opts.zepProjectId,
     };
@@ -431,13 +421,11 @@ export async function initCommand(opts: IInitOptions, services: IServices): Prom
       modeConfig = { endpoint: DEFAULT_ENDPOINT };
     }
 
-    const groupId = await promptGroupId();
     cliSupport = await promptCliSupport();
 
     config = {
       mode,
       endpoint: modeConfig.endpoint || DEFAULT_ENDPOINT,
-      groupId,
       ...modeConfig,
     };
   }
@@ -446,11 +434,10 @@ export async function initCommand(opts: IInitOptions, services: IServices): Prom
   const supportClaudeCode = cliSupport.includes('claude-code');
   const supportOpenCode = cliSupport.includes('opencode');
 
+  const projectName = path.basename(cwd);
   const replacements = {
     GRAPHITI_ENDPOINT: config.endpoint,
-    GRAPHITI_GROUP: config.groupId,
-    GRAPHITI_GROUP_ID: config.groupId,
-    PROJECT_NAME: config.groupId,
+    PROJECT_NAME: projectName,
   };
 
   const lisaDir = path.join(cwd, '.lisa');
@@ -627,7 +614,6 @@ export async function initCommand(opts: IInitOptions, services: IServices): Prom
   console.log(chalk.green(`Scaffolded ${scaffoldedDirs.join(', ')} into ${cwd}`));
   console.log(`Mode: ${config.mode}`);
   console.log(`Endpoint: ${config.endpoint}`);
-  console.log(`Group ID: ${config.groupId}`);
   console.log(`CLI Support: ${cliSupport.join(', ')}`);
 
   if (config.mode === 'skip') {

--- a/src/lib/commands/shared/constants.ts
+++ b/src/lib/commands/shared/constants.ts
@@ -22,7 +22,8 @@ export const ZEP_CLOUD_ENDPOINT = 'https://api.getzep.com/mcp/';
 
 /**
  * Get project name from package.json or directory name.
- * Used as the default group ID for memory storage.
+ * Used for display purposes (e.g., init output). NOT used for group ID routing -
+ * group IDs are derived from the full folder path via getCurrentGroupId().
  */
 export function getProjectName(): string {
   try {
@@ -51,11 +52,11 @@ export type CliSupport = 'claude-code' | 'opencode';
 
 /**
  * Graphiti configuration interface.
+ * Note: groupId is no longer configurable - it's derived from the project folder path.
  */
 export interface IGraphitiConfig {
   mode: DeploymentMode;
   endpoint: string;
-  groupId: string;
   // Zep Cloud specific
   zepApiKey?: string;
   zepProjectId?: string;

--- a/src/lib/skills/github/github.ts
+++ b/src/lib/skills/github/github.ts
@@ -350,8 +350,9 @@ async function handleSync(
     direction = 'export';
   }
 
-  // Get group ID (default to repo name)
-  const groupId = (args.group as string) || repo.replace('/', '-');
+  // Get group ID (use canonical folder-based group, allow --group override)
+  const { getCurrentGroupId } = await import('../shared/group-id');
+  const groupId = (args.group as string) || getCurrentGroupId();
 
   // Create dependencies
   const ghCli = createGhCliClientFromEnv();

--- a/src/lib/skills/init-review/ai-enrich.ts
+++ b/src/lib/skills/init-review/ai-enrich.ts
@@ -12,6 +12,7 @@ export {};
 
 import fs from 'fs';
 import path from 'path';
+import { getCurrentGroupId } from '../shared/group-id';
 
 interface IStaticAnalysis {
   summary: string;
@@ -37,8 +38,8 @@ function log(message: string): void {
   fs.appendFileSync(LOG_FILE, `[${new Date().toISOString()}] ${message}\n`);
 }
 
-function loadConfig(): { endpoint: string; groupId: string; zepApiKey: string } {
-  const config = { endpoint: 'http://localhost:8010/mcp/', groupId: path.basename(projectRoot).toLowerCase().replace(/[^a-z0-9-]/g, '-'), zepApiKey: '' };
+function loadConfig(): { endpoint: string; zepApiKey: string } {
+  const config = { endpoint: 'http://localhost:8010/mcp/', zepApiKey: '' };
   const envPath = path.join(agentsDir, '.env');
 
   try {
@@ -47,7 +48,6 @@ function loadConfig(): { endpoint: string; groupId: string; zepApiKey: string } 
       for (const line of content.split('\n')) {
         const [key, value] = line.split('=').map(s => s.trim());
         if (key === 'GRAPHITI_ENDPOINT') config.endpoint = value;
-        if (key === 'GRAPHITI_GROUP_ID') config.groupId = value;
         if (key === 'ZEP_API_KEY') config.zepApiKey = value;
       }
     }
@@ -156,12 +156,13 @@ async function main(): Promise<void> {
   log(`Generated enriched summary: ${enrichedSummary.slice(0, 100)}...`);
 
   const config = loadConfig();
-  log(`Using endpoint: ${config.endpoint}, group: ${config.groupId}`);
+  const groupId = getCurrentGroupId(projectRoot);
+  log(`Using endpoint: ${config.endpoint}, group: ${groupId}`);
 
   const sessionId = await initializeMCP(config.endpoint, config.zepApiKey);
   if (!sessionId) { log('Could not initialize MCP'); return; }
 
-  const success = await addEnrichedMemory(config.endpoint, sessionId, enrichedSummary, config.groupId, config.zepApiKey);
+  const success = await addEnrichedMemory(config.endpoint, sessionId, enrichedSummary, groupId, config.zepApiKey);
 
   if (success) {
     log('Successfully stored enriched memory');

--- a/src/lib/skills/memory/memory.ts
+++ b/src/lib/skills/memory/memory.ts
@@ -29,8 +29,6 @@ async function main(): Promise<void> {
 
   const command = args.shift() ?? '';
   const explicitGroup = popFlag(args, '--group', null);
-  const envGroup = env.GRAPHITI_GROUP_ID;
-  const hasConfiguredGroup = !!(explicitGroup || envGroup);
   const query = popFlag(args, '--query', '');
   const limit = Number(popFlag(args, '--limit', '10')) || 10;
   const explicitTag = popFlag(args, '--tag', null);
@@ -55,7 +53,7 @@ async function main(): Promise<void> {
 
   try {
     const result = await cliService.run({
-      command, payload, explicitGroup, hasConfiguredGroup, query, limit, explicitTag, entityType, source, since, until,
+      command, payload, explicitGroup, query, limit, explicitTag, entityType, source, since, until,
     });
     console.log(JSON.stringify(result, null, 2));
   } catch (err: unknown) {

--- a/src/lib/skills/prompt/prompt.ts
+++ b/src/lib/skills/prompt/prompt.ts
@@ -20,7 +20,8 @@ async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
   const explicitGroup = popFlag(args, '--group', null);
-  const groupId = explicitGroup || env.GRAPHITI_GROUP_ID || getCurrentGroupId();
+  // Use explicit --group if provided, otherwise use canonical folder-based group ID
+  const groupId = explicitGroup || getCurrentGroupId();
   const text = popFlag(args, '--text', null) || popFlag(args, '-t', null);
   const role = popFlag(args, '--role', 'user') || popFlag(args, '-r', 'user');
   const source = popFlag(args, '--source', 'user-prompt') || popFlag(args, '-s', 'user-prompt');

--- a/src/lib/skills/shared/services/MemoryCliService.ts
+++ b/src/lib/skills/shared/services/MemoryCliService.ts
@@ -19,7 +19,6 @@ export interface IMemoryCliArgs {
   command: string;
   payload: string;
   explicitGroup: string | null;
-  hasConfiguredGroup: boolean;
   query: string;
   limit: number;
   explicitTag: string | null;
@@ -57,20 +56,22 @@ export function createMemoryCliService(deps: IMemoryCliDependencies): IMemoryCli
 
   return {
     async run(args: IMemoryCliArgs): Promise<IMemoryLoadResult | IMemoryAddResult> {
-      const { command, payload, explicitGroup, hasConfiguredGroup, query, limit, explicitTag, entityType, source, since, until } = args;
+      const { command, payload, explicitGroup, query, limit, explicitTag, entityType, source, since, until } = args;
 
       if (!['add', 'load'].includes(command)) {
         throw new Error('command must be add|load');
       }
 
-      const groupId = explicitGroup || env.GRAPHITI_GROUP_ID || getCurrentGroupId();
+      // Use explicit --group if provided, otherwise use canonical folder-based group ID
+      const groupId = explicitGroup || getCurrentGroupId();
 
       logger.info(`Executing command: ${command}`, { mode: env.STORAGE_MODE, group: groupId });
 
       let result: IMemoryLoadResult | IMemoryAddResult;
 
       if (command === 'load') {
-        const groupIds = hasConfiguredGroup ? [groupId] : getGroupIds();
+        // Always use canonical group IDs for loading (hierarchical lookup)
+        const groupIds = explicitGroup ? [explicitGroup] : getGroupIds();
         logger.debug('Using Neo4j direct mode for load');
         
         // Parse date filters - throw error on invalid values

--- a/src/lib/skills/shared/services/StorageService.ts
+++ b/src/lib/skills/shared/services/StorageService.ts
@@ -3,6 +3,7 @@
  */
 import fs from 'fs';
 import { execSync } from 'child_process';
+import { getCurrentGroupId } from '../group-id';
 
 // ============================================================================
 // Types
@@ -107,12 +108,7 @@ export function createStorageService(deps: IStorageServiceDependencies): IStorag
       });
 
       if (!foundMode) {
-        const groupIdx = updatedLines.findIndex((l: string) => l.startsWith('GRAPHITI_GROUP_ID'));
-        if (groupIdx !== -1) {
-          updatedLines.splice(groupIdx + 1, 0, `STORAGE_MODE=${newMode}`);
-        } else {
-          updatedLines.push(`STORAGE_MODE=${newMode}`);
-        }
+        updatedLines.push(`STORAGE_MODE=${newMode}`);
       }
 
       if (!foundEndpoint) {
@@ -198,7 +194,7 @@ export function createStorageService(deps: IStorageServiceDependencies): IStorag
       const env = service.readEnvConfig();
       const mode = env.STORAGE_MODE || process.env.STORAGE_MODE || 'local';
       const endpoint = env.GRAPHITI_ENDPOINT || process.env.GRAPHITI_ENDPOINT || defaultLocalEndpoint;
-      const groupId = env.GRAPHITI_GROUP_ID || process.env.GRAPHITI_GROUP_ID || 'lisa';
+      const groupId = getCurrentGroupId();
 
       let isConnected = false;
       let connectionError: string | undefined;

--- a/src/lib/skills/shared/services/TaskCliService.ts
+++ b/src/lib/skills/shared/services/TaskCliService.ts
@@ -104,7 +104,8 @@ export function createTaskCliService(deps: ITaskCliDependencies): ITaskCliServic
         throw new Error(`command must be ${validCommands.join('|')}`);
       }
 
-      const groupId = explicitGroup || env.GRAPHITI_GROUP_ID || getCurrentGroupId();
+      // Use explicit --group if provided, otherwise use canonical folder-based group ID
+      const groupId = explicitGroup || getCurrentGroupId();
 
       logger.info(`Executing command: ${command}`, { mode: env.STORAGE_MODE, group: groupId });
 

--- a/src/lib/skills/shared/utils/env.ts
+++ b/src/lib/skills/shared/utils/env.ts
@@ -14,7 +14,6 @@ export interface IEnvConfig {
 
   // Graphiti MCP settings
   GRAPHITI_ENDPOINT: string;
-  GRAPHITI_GROUP_ID?: string;
 
   // Neo4j settings
   NEO4J_URI: string;
@@ -100,7 +99,6 @@ export function loadEnv(): IEnvConfig {
     STORAGE_MODE: storageMode,
 
     GRAPHITI_ENDPOINT: get('GRAPHITI_ENDPOINT', 'http://localhost:8010/mcp/'),
-    GRAPHITI_GROUP_ID: get('GRAPHITI_GROUP_ID') || undefined,
 
     NEO4J_URI: get('NEO4J_URI', 'bolt://localhost:7687'),
     NEO4J_USER: get('NEO4J_USER', 'neo4j'),

--- a/src/lib/skills/shared/utils/group-id.ts
+++ b/src/lib/skills/shared/utils/group-id.ts
@@ -1,33 +1,90 @@
 /**
  * Shared group ID utilities for folder-based memory isolation.
  * Used by memory, tasks, and other skills.
+ * 
+ * The group ID is derived from the project root (where .lisa directory exists).
+ * This ensures consistent group IDs regardless of where in the project you run commands.
  */
 import path from 'path';
+import fs from 'fs';
 
 /**
- * Get the current folder's group ID (uses folder basename).
- * E.g., "lisa" from "C:\dev\lisa" or "/home/user/projects/lisa"
+ * Find the .lisa directory by traversing up from the given directory.
+ * @param startDir - Directory to start searching from
+ * @returns Path to .lisa directory or null if not found
+ */
+function findLisaDir(startDir: string): string | null {
+  let dir = startDir;
+  
+  // Traverse up to 10 levels looking for .lisa
+  for (let i = 0; i < 10; i++) {
+    const lisaDir = path.join(dir, '.lisa');
+    if (fs.existsSync(lisaDir) && fs.statSync(lisaDir).isDirectory()) {
+      return lisaDir;
+    }
+    
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // Reached root
+    dir = parent;
+  }
+  
+  return null;
+}
+
+/**
+ * Get the project root directory (parent of .lisa directory).
+ * @param cwd - Current working directory (defaults to process.cwd())
+ * @returns Project root path or cwd if .lisa not found
+ */
+function getProjectRoot(cwd: string = process.cwd()): string {
+  const lisaDir = findLisaDir(cwd);
+  if (lisaDir) {
+    return path.dirname(lisaDir);
+  }
+  // Fallback: use current directory
+  return cwd;
+}
+
+/**
+ * Get the canonical group ID based on the project root path.
+ * The group ID is the full normalized path where .lisa was initialized.
+ * 
+ * Cross-platform: Works on Windows (\), Mac/Linux (/)
  * 
  * @param cwd - Current working directory (defaults to process.cwd())
  * @returns Normalized group ID
  */
 export function getCurrentGroupId(cwd: string = process.cwd()): string {
-  const basename = path.basename(cwd);
-  return normalizeGroupId(basename);
+  const projectRoot = getProjectRoot(cwd);
+  return normalizeGroupId(projectRoot);
 }
 
 /**
- * Normalize a string to a valid Graphiti group ID.
+ * Normalize a path to a valid Graphiti group ID.
  * Graphiti requires alphanumeric characters, dashes, and underscores only.
  * 
- * @param input - String to normalize
+ * Cross-platform path handling:
+ * - Windows: C:\dev\lisa -> c-dev-lisa
+ * - Unix: /home/user/lisa -> home-user-lisa
+ * 
+ * @param input - Path string to normalize
  * @returns Normalized group ID
  */
 export function normalizeGroupId(input: string): string {
   return input
     .toLowerCase()
-    .replace(/\./g, '_')           // Replace dots with underscores
-    .replace(/[^a-z0-9_-]/g, '-'); // Replace other invalid chars with dashes
+    // Remove drive letter colon (Windows C: -> c, must run before path separator replacement)
+    .replace(/^([a-z]):/, '$1')
+    // Normalize path separators (Windows \ and Unix /) to dash
+    .replace(/[\\/]+/g, '-')
+    // Replace dots with underscores
+    .replace(/\./g, '_')
+    // Replace any remaining invalid chars with dashes
+    .replace(/[^a-z0-9_-]/g, '-')
+    // Remove leading/trailing dashes
+    .replace(/^-+|-+$/g, '')
+    // Collapse multiple consecutive dashes
+    .replace(/-+/g, '-');
 }
 
 /**
@@ -38,13 +95,13 @@ export function normalizeGroupId(input: string): string {
  * @returns Array of group IDs to query
  */
 export function getGroupIds(cwd: string = process.cwd()): string[] {
-  const groupId = getCurrentGroupId(cwd);
-  return groupId ? [groupId] : [];
+  return getGroupIdsWithLegacy(cwd);
 }
 
 /**
  * Generate a hierarchical list of group IDs from a path.
- * E.g., "/home/user/projects/lisa/src" returns ["lisa", "projects", "user"]
+ * Uses the full normalized path and its parent paths.
+ * E.g., "/home/user/projects/lisa" returns ["home-user-projects-lisa", "home-user-projects", "home-user"]
  * 
  * This allows querying memories from parent directories as well.
  * 
@@ -60,10 +117,9 @@ export function getHierarchicalGroupIds(
   let currentPath = cwd;
 
   for (let i = 0; i < maxDepth; i++) {
-    const basename = path.basename(currentPath);
-    if (!basename || basename === currentPath) break; // Reached root
+    if (!currentPath || currentPath === path.dirname(currentPath)) break; // Reached root
 
-    const groupId = normalizeGroupId(basename);
+    const groupId = normalizeGroupId(currentPath);
     if (groupId && !groupIds.includes(groupId)) {
       groupIds.push(groupId);
     }
@@ -72,6 +128,36 @@ export function getHierarchicalGroupIds(
   }
 
   return groupIds;
+}
+
+/**
+ * Get group IDs for querying with backward compatibility.
+ * Includes the canonical group ID plus the legacy basename-based ID for migration.
+ * 
+ * This ensures existing data stored under the old basename format (e.g., "lisa")
+ * is still accessible while new data uses the full path format (e.g., "c-dev-lisa").
+ * 
+ * @param cwd - Current working directory (defaults to process.cwd())
+ * @returns Array of group IDs to query (canonical + legacy)
+ */
+export function getGroupIdsWithLegacy(cwd: string = process.cwd()): string[] {
+  const groupIds = new Set<string>();
+  
+  // Add canonical full-path group ID
+  const canonicalId = getCurrentGroupId(cwd);
+  if (canonicalId) {
+    groupIds.add(canonicalId);
+  }
+  
+  // Add legacy basename-based group ID for backward compatibility
+  // This allows reading old data stored under the previous naming scheme
+  const projectRoot = getProjectRoot(cwd);
+  const legacyId = normalizeGroupId(path.basename(projectRoot));
+  if (legacyId && legacyId !== canonicalId) {
+    groupIds.add(legacyId);
+  }
+  
+  return Array.from(groupIds);
 }
 
 /**

--- a/src/lib/skills/shared/utils/index.ts
+++ b/src/lib/skills/shared/utils/index.ts
@@ -18,6 +18,7 @@ export {
 export {
   getCurrentGroupId,
   getGroupIds,
+  getGroupIdsWithLegacy,
   getHierarchicalGroupIds,
   normalizeGroupId,
   createZepUserId,

--- a/src/project/.lisa/.env.template
+++ b/src/project/.lisa/.env.template
@@ -14,6 +14,3 @@ NEO4J_URI=bolt://localhost:7687
 NEO4J_USER=neo4j
 NEO4J_PASSWORD=demodemo
 NEO4J_DATABASE=neo4j
-
-# Group ID (optional - defaults to folder name)
-# GRAPHITI_GROUP_ID={{GRAPHITI_GROUP_ID}}

--- a/src/project/.lisa/skills/memory/SKILL.md
+++ b/src/project/.lisa/skills/memory/SKILL.md
@@ -12,7 +12,7 @@ Use when the user says things like: "load memory", "recall notes", "remember", "
 ## How to use
 1) For recall: run `lisa memory load --cache [--query <q>] [--limit 10] [--group <id>]`. Reads Graphiti facts and prints JSON. Uses cache if MCP is down.
 2) For remember: run `lisa memory add "<text>" --cache [--group <id>] [--tag foo] [--source <src>]` to append an episode.
-3) Endpoint/group: reads ${GRAPHITI_ENDPOINT} / ${GRAPHITI_GROUP_ID} from `.lisa/.env` (written by init); see root `AGENTS.md` for canonical defaults.
+3) Endpoint: reads ${GRAPHITI_ENDPOINT} from `.lisa/.env` (written by init); group ID is automatically derived from the project folder path. See root `AGENTS.md` for canonical defaults.
 4) Cache fallback: stored at `cache/memory.log` inside this skill. On failure, last cached result is returned with `status: "fallback"`.
 5) **IMPORTANT: After loading facts, ALWAYS synthesize them into a human-readable summary (see Summarization section below).**
 

--- a/src/project/.lisa/skills/prompt/SKILL.md
+++ b/src/project/.lisa/skills/prompt/SKILL.md
@@ -12,7 +12,7 @@ Store every prompt (and optional role/kind) as a memory episode in Graphiti MCP,
 
 ## Usage
 - `lisa-prompt add --text "..." [--role user|assistant] [--kind Direction|Decision|Requirement|Observation] [--force]`
-- By default uses `GRAPHITI_ENDPOINT` and `GRAPHITI_GROUP_ID` from `.lisa/.env`. Falls back to `http://localhost:8010/mcp/` and `lisa`.
+- By default uses `GRAPHITI_ENDPOINT` from `.lisa/.env`. Group ID is automatically derived from the project folder path. Falls back to `http://localhost:8010/mcp/`.
 
 ## Notes
 - Adds a fingerprint tag to avoid duplicate prompts unless `--force` is passed.

--- a/src/project/.lisa/skills/tasks/SKILL.md
+++ b/src/project/.lisa/skills/tasks/SKILL.md
@@ -12,7 +12,7 @@ Use when the user says: "add a task", "list tasks", "load tasks", "task status".
 ## How to use
 1) List: `lisa tasks list --cache [--group <id>] [--limit 20]`
 2) Add: `lisa tasks add "<task text>" [--status todo|doing|done] [--tag foo] [--group <id>] --cache`
-3) Defaults: reads ${GRAPHITI_ENDPOINT} / ${GRAPHITI_GROUP_ID} from `.lisa/.env` (written by init); see root `AGENTS.md` for canonical defaults.
+3) Defaults: reads ${GRAPHITI_ENDPOINT} from `.lisa/.env` (written by init); group ID is automatically derived from the project folder path. See root `AGENTS.md` for canonical defaults.
 4) Cache fallback: writes/reads `cache/tasks.log` when `--cache` is passed, returning last cached result on MCP failure.
 5) Keep prompts model-neutral; models only orchestrate script calls and summarize JSON output.
 

--- a/tests/unit/src/cli.test.ts
+++ b/tests/unit/src/cli.test.ts
@@ -72,7 +72,8 @@ test('initCommand copies expected templates with replacements', async () => {
   const rulesCopy = services.templateCopier.calls.find((c) => c.dest.includes('rules') && c.dest.includes('clean-architecture'));
   assert.ok(rulesCopy, 'rules should be copied');
   assert.equal(rulesCopy?.replacements.GRAPHITI_ENDPOINT, DEFAULT_ENDPOINT);
-  assert.equal(rulesCopy?.replacements.GRAPHITI_GROUP, DEFAULT_GROUP);
+  // GRAPHITI_GROUP replacement removed - group ID is now derived from folder path
+  assert.ok(rulesCopy?.replacements.PROJECT_NAME, 'PROJECT_NAME replacement should be set');
 });
 
 test('initCommand skips docker assets when includeDocker is false', async () => {

--- a/tests/unit/src/lib/commands/doctor.test.ts
+++ b/tests/unit/src/lib/commands/doctor.test.ts
@@ -258,38 +258,35 @@ describe('Doctor Command', () => {
       fs.mkdirSync(path.join(tempDir, '.lisa', 'rules'), { recursive: true });
       fs.writeFileSync(
         path.join(tempDir, '.lisa', '.env'),
-        'STORAGE_MODE=local\nGRAPHITI_GROUP_ID=my-project\nGRAPHITI_ENDPOINT=http://localhost:8010/mcp/\n'
+        'STORAGE_MODE=local\nGRAPHITI_ENDPOINT=http://localhost:8010/mcp/\n'
       );
 
       const services = createMockServices();
       const result = await runDoctor({ cwd: tempDir }, services);
 
       assert.strictEqual(result.config.mode, 'local');
-      assert.strictEqual(result.config.group, 'my-project');
+      // Group is now derived from folder path, not from env
+      assert.ok(result.config.group.length > 0, 'Group should be derived from folder path');
       assert.strictEqual(result.config.endpoint, 'http://localhost:8010/mcp/');
       assert.strictEqual(result.config.envFileExists, true);
     });
 
-    it('should use default group from project name when not configured', async () => {
+    it('should derive group from folder path regardless of env config', async () => {
       fs.mkdirSync(path.join(tempDir, '.lisa', 'skills'), { recursive: true });
       fs.mkdirSync(path.join(tempDir, '.lisa', 'rules'), { recursive: true });
-      // Create .env with no group
       fs.writeFileSync(
         path.join(tempDir, '.lisa', '.env'),
         'STORAGE_MODE=skip\n'
       );
 
-      // Create package.json
-      fs.writeFileSync(
-        path.join(tempDir, 'package.json'),
-        JSON.stringify({ name: '@scope/my-app' })
-      );
-
       const services = createMockServices();
       const result = await runDoctor({ cwd: tempDir }, services);
 
-      // Should use package name without scope
-      assert.strictEqual(result.config.group, 'my-app');
+      // Group should be the normalized folder path, not a package name or env var
+      assert.ok(result.config.group.length > 0, 'Group should be non-empty');
+      assert.ok(!result.config.group.includes(':'), 'Group should not contain colons');
+      assert.ok(!result.config.group.includes('\\'), 'Group should not contain backslashes');
+      assert.ok(!result.config.group.includes('/'), 'Group should not contain forward slashes');
     });
   });
 

--- a/tests/unit/src/lib/skills/shared/utils/group-id.test.ts
+++ b/tests/unit/src/lib/skills/shared/utils/group-id.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Tests for group-id utility functions.
+ *
+ * Covers:
+ * - normalizeGroupId() with Windows and Unix paths
+ * - getCurrentGroupId() with .lisa directory traversal
+ * - getGroupIdsWithLegacy() backward compatibility
+ * - getHierarchicalGroupIds() parent path generation
+ */
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  normalizeGroupId,
+  getCurrentGroupId,
+  getGroupIds,
+  getGroupIdsWithLegacy,
+  getHierarchicalGroupIds,
+  createZepUserId,
+  createZepThreadId,
+} from '../../../../../../../src/lib/skills/shared/utils/group-id';
+
+describe('group-id', () => {
+  describe('normalizeGroupId()', () => {
+    it('should normalize a Windows path', () => {
+      const result = normalizeGroupId('C:\\dev\\lisa');
+      assert.strictEqual(result, 'c-dev-lisa');
+    });
+
+    it('should normalize a Unix path', () => {
+      const result = normalizeGroupId('/home/user/lisa');
+      assert.strictEqual(result, 'home-user-lisa');
+    });
+
+    it('should handle Windows path with deep nesting', () => {
+      const result = normalizeGroupId('C:\\Users\\tony\\Projects\\my-app');
+      assert.strictEqual(result, 'c-users-tony-projects-my-app');
+    });
+
+    it('should handle Unix path with deep nesting', () => {
+      const result = normalizeGroupId('/home/tony/projects/my-app');
+      assert.strictEqual(result, 'home-tony-projects-my-app');
+    });
+
+    it('should replace dots with underscores', () => {
+      const result = normalizeGroupId('/home/tony.casey/repos/api');
+      assert.strictEqual(result, 'home-tony_casey-repos-api');
+    });
+
+    it('should collapse multiple consecutive separators', () => {
+      const result = normalizeGroupId('/home//user///lisa');
+      assert.strictEqual(result, 'home-user-lisa');
+    });
+
+    it('should handle simple basename input', () => {
+      const result = normalizeGroupId('lisa');
+      assert.strictEqual(result, 'lisa');
+    });
+
+    it('should lowercase everything', () => {
+      const result = normalizeGroupId('MyProject');
+      assert.strictEqual(result, 'myproject');
+    });
+
+    it('should handle empty string', () => {
+      const result = normalizeGroupId('');
+      assert.strictEqual(result, '');
+    });
+
+    it('should remove trailing separators', () => {
+      const result = normalizeGroupId('/home/user/lisa/');
+      assert.strictEqual(result, 'home-user-lisa');
+    });
+
+    it('should handle mixed separators', () => {
+      const result = normalizeGroupId('C:\\Users/tony\\projects/app');
+      assert.strictEqual(result, 'c-users-tony-projects-app');
+    });
+  });
+
+  describe('getCurrentGroupId()', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lisa-group-id-test-'));
+    });
+
+    afterEach(() => {
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    it('should find .lisa in current directory', () => {
+      fs.mkdirSync(path.join(tempDir, '.lisa'), { recursive: true });
+      const result = getCurrentGroupId(tempDir);
+      assert.strictEqual(result, normalizeGroupId(tempDir));
+    });
+
+    it('should find .lisa in parent directory', () => {
+      fs.mkdirSync(path.join(tempDir, '.lisa'), { recursive: true });
+      const subDir = path.join(tempDir, 'src', 'lib');
+      fs.mkdirSync(subDir, { recursive: true });
+      const result = getCurrentGroupId(subDir);
+      // Should resolve to tempDir (where .lisa is), not subDir
+      assert.strictEqual(result, normalizeGroupId(tempDir));
+    });
+
+    it('should find .lisa several levels up', () => {
+      fs.mkdirSync(path.join(tempDir, '.lisa'), { recursive: true });
+      const deepDir = path.join(tempDir, 'src', 'lib', 'skills', 'shared');
+      fs.mkdirSync(deepDir, { recursive: true });
+      const result = getCurrentGroupId(deepDir);
+      assert.strictEqual(result, normalizeGroupId(tempDir));
+    });
+
+    it('should return a valid normalized group ID even without local .lisa', () => {
+      // No .lisa directory in tempDir - may find one in an ancestor directory.
+      // Either way, the result should be a valid normalized group ID.
+      const result = getCurrentGroupId(tempDir);
+      assert.ok(result.length > 0, 'Should return a non-empty group ID');
+      assert.ok(!/[:\\\/]/.test(result), 'Should not contain path separators or colons');
+    });
+
+    it('should produce consistent IDs from different subdirectories', () => {
+      fs.mkdirSync(path.join(tempDir, '.lisa'), { recursive: true });
+      const dir1 = path.join(tempDir, 'src');
+      const dir2 = path.join(tempDir, 'tests', 'unit');
+      fs.mkdirSync(dir1, { recursive: true });
+      fs.mkdirSync(dir2, { recursive: true });
+
+      const id1 = getCurrentGroupId(dir1);
+      const id2 = getCurrentGroupId(dir2);
+      const idRoot = getCurrentGroupId(tempDir);
+
+      assert.strictEqual(id1, id2, 'IDs from different subdirectories should match');
+      assert.strictEqual(id1, idRoot, 'Subdirectory ID should match root ID');
+    });
+  });
+
+  describe('getGroupIdsWithLegacy()', () => {
+    let tempDir: string;
+
+    beforeEach(() => {
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lisa-group-id-test-'));
+    });
+
+    afterEach(() => {
+      try {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup errors
+      }
+    });
+
+    it('should include both canonical and legacy IDs', () => {
+      fs.mkdirSync(path.join(tempDir, '.lisa'), { recursive: true });
+      const result = getGroupIdsWithLegacy(tempDir);
+
+      const canonicalId = normalizeGroupId(tempDir);
+      const legacyId = normalizeGroupId(path.basename(tempDir));
+
+      assert.ok(result.includes(canonicalId), 'Should include canonical full-path ID');
+      if (legacyId !== canonicalId) {
+        assert.ok(result.includes(legacyId), 'Should include legacy basename ID');
+      }
+    });
+
+    it('should not duplicate when canonical equals legacy', () => {
+      // If the folder name equals the full path normalization (unlikely but test the logic)
+      const result = getGroupIdsWithLegacy(tempDir);
+      const uniqueIds = new Set(result);
+      assert.strictEqual(result.length, uniqueIds.size, 'Should not contain duplicates');
+    });
+
+    it('should match getGroupIds output', () => {
+      fs.mkdirSync(path.join(tempDir, '.lisa'), { recursive: true });
+      const legacy = getGroupIdsWithLegacy(tempDir);
+      const regular = getGroupIds(tempDir);
+      assert.deepStrictEqual(regular, legacy, 'getGroupIds should delegate to getGroupIdsWithLegacy');
+    });
+  });
+
+  describe('getHierarchicalGroupIds()', () => {
+    it('should return group IDs for path and parents', () => {
+      const result = getHierarchicalGroupIds('/home/user/projects/lisa', 3);
+      assert.strictEqual(result.length, 3);
+      assert.strictEqual(result[0], 'home-user-projects-lisa');
+      assert.strictEqual(result[1], 'home-user-projects');
+      assert.strictEqual(result[2], 'home-user');
+    });
+
+    it('should respect maxDepth', () => {
+      const result = getHierarchicalGroupIds('/home/user/projects/lisa', 1);
+      assert.strictEqual(result.length, 1);
+      assert.strictEqual(result[0], 'home-user-projects-lisa');
+    });
+
+    it('should not include duplicates', () => {
+      const result = getHierarchicalGroupIds('/home/user', 5);
+      const unique = new Set(result);
+      assert.strictEqual(result.length, unique.size);
+    });
+  });
+
+  describe('createZepUserId()', () => {
+    it('should prefix with lisa-', () => {
+      assert.strictEqual(createZepUserId('my-project'), 'lisa-my-project');
+    });
+  });
+
+  describe('createZepThreadId()', () => {
+    it('should create thread ID with purpose', () => {
+      assert.strictEqual(createZepThreadId('my-project', 'memory'), 'lisa-memory-my-project');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix: canonical group-id derived from project folder path

## Test Coverage
- `tests/unit/src/cli.test.ts`
- `tests/unit/src/lib/commands/doctor.test.ts`
- `tests/unit/src/lib/skills/shared/utils/group-id.test.ts`

## Linked Issues
Closes #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Group ID is now automatically derived from the project folder path, eliminating the need for manual GRAPHITI_GROUP_ID configuration.

* **Documentation**
  * Updated all guides to reflect automatic group ID derivation, simplifying project setup and configuration.

* **Tests**
  * Added comprehensive tests validating group ID derivation behavior across various folder path scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->