### PR TITLE
chore(release): v2.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [2.12.0] - 2026-01-31
 
 ### Changed
 
@@ -103,6 +103,26 @@ Eliminated the competing service construction paths, establishing one clear comp
 - **Hooks/handlers** (session-start, session-stop, prompt-submit) → `bootstrapContainer()` in `bootstrap.ts`
 
 **Result:** One clear composition root per concern, zero deprecated service factory functions, and the DI container index documents both paths with JSDoc.
+
+### Fixed
+
+#### Canonical group-id derived from project folder path ([#90](https://github.com/TonyCasey/lisa/issues/90))
+
+Group ID is now derived from the project folder name (or `package.json` name) instead of being a user-configurable `.env` value. Removes `GRAPHITI_GROUP_ID` from `.env.template` and all code paths.
+
+#### Persist GitHub issue creation in local mode ([#91](https://github.com/TonyCasey/lisa/issues/91))
+
+Fixed GitHub issue creation not persisting in local storage mode.
+
+#### Default tasks list to today ([#92](https://github.com/TonyCasey/lisa/issues/92))
+
+`lisa tasks list` now defaults to querying from today instead of returning all tasks.
+
+#### Enable hook logging and fix .env inline comment parsing ([#107](https://github.com/TonyCasey/lisa/issues/107))
+
+- Hook commands were bootstrapping with `disableLogging: true`, creating a `NullLogger` — zero operational logs were written. Removed the flag so hooks now write to `.lisa/logs/`.
+- Fixed `.env` inline comment parsing in both `readEnvFile` implementations (`"true # comment"` was parsed as the full string instead of `"true"`).
+- Fixed 3 integration tests and e2e docker tests broken by `GRAPHITI_GROUP_ID` removal in PR #90.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tonycasey/lisa",
-  "version": "2.11.0",
+  "version": "2.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tonycasey/lisa",
-      "version": "2.11.0",
+      "version": "2.12.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tonycasey/lisa",
-  "version": "2.11.5",
+  "version": "2.12.0",
   "description": "Long-term memory for AI coding assistants. Automatic context persistence, task tracking, and knowledge capture across coding sessions. Supports Claude Code and OpenCode.",
   "bin": {
     "lisa": "dist/lib/cli.js",


### PR DESCRIPTION
## Release v2.12.0

### Changed (Refactoring)
- **Decompose cli.ts** (#81) — 1,951-line monolith split into 6 focused command modules
- **Split SessionStartHandler** (#82) — 818 lines decomposed into 3 focused services
- **Move shell/git behind interfaces** (#83) — `IGitClient` + `IClaudeCliClient` domain interfaces
- **Replace execSync with safe process runner** (#84) — zero `execSync` calls remain in `src/lib/`
- **Centralize process.exit at CLI boundary** (#85) — `CliExitError` replaces 34 `process.exit()` calls
- **Consolidate legacy services.ts with DI** (#86) — one composition root per concern, zero deprecated code

### Fixed
- **Canonical group-id from folder path** (#90) — removes `GRAPHITI_GROUP_ID` from `.env`
- **Persist GitHub issue creation in local mode** (#91)
- **Default tasks list to today** (#92)
- **Enable hook logging + fix .env comment parsing** (#107) — hooks were silently discarding all logs

### Verification
- [x] Build passes
- [x] 876 unit tests pass
- [x] 40 integration tests pass
- [x] Linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release 2.12.0

* **Bug Fixes**
  * Group ID now derived from project folder path
  * GitHub issue creation now persists in local mode
  * Tasks list defaults to today instead of all tasks
  * Hook logging enabled; fixed .env file inline comment parsing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->