### PR TITLE
feat(memory): Add memory lifecycle domain types and expiration filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+
+#### Memory Lifecycle Domain Types ([#111](https://github.com/TonyCasey/lisa/issues/111))
+
+Added domain types and interfaces for memory lifecycle tiers, enabling retention control and TTL-based expiration for memory facts.
+
+- `MemoryLifecycle` type with four tiers: `permanent`, `project`, `session`, `ephemeral`
+- Utility functions: `resolveLifecycleTag()`, `parseLifecycleTag()`, `isValidLifecycle()`, `computeExpiresAt()`
+- `IExpirationFilter` interface for expiration queries
+- `IMemoryRepositoryExpiration` interface with `expire()` and `expireByFilter()` methods
+- `IReadOnlyMemoryRepositoryWithExpiration` composite interface
+- Extended `IMemorySaveOptions` with `lifecycle` and `ttlMs` fields
+
+Part of Epic [#110](https://github.com/TonyCasey/lisa/issues/110)
+
+---
+
 ## [2.12.0] - 2026-01-31
 
 ### Changed

--- a/src/lib/domain/interfaces/dal/IMemoryRepository.ts
+++ b/src/lib/domain/interfaces/dal/IMemoryRepository.ts
@@ -6,7 +6,8 @@
  */
 
 import { IMemoryItem } from '../types/IMemoryResult';
-import { IQueryOptions, IMemoryQueryResult } from './types';
+import type { MemoryLifecycle } from '../types/IMemoryLifecycle';
+import { IQueryOptions, IMemoryQueryResult, IExpirationFilter } from './types';
 
 /**
  * Options for saving memory.
@@ -16,6 +17,10 @@ export interface IMemorySaveOptions {
   readonly tags?: readonly string[];
   /** Source identifier (e.g., 'session-stop', 'user-explicit') */
   readonly source?: string;
+  /** Lifecycle tier for retention control */
+  readonly lifecycle?: MemoryLifecycle;
+  /** Custom TTL override in milliseconds (overrides lifecycle default) */
+  readonly ttlMs?: number;
 }
 
 /**
@@ -111,6 +116,28 @@ export interface IMemoryRepositoryCapabilities {
 }
 
 /**
+ * Expiration operations for memory repositories.
+ * Separated interface since not all backends support direct expiration.
+ */
+export interface IMemoryRepositoryExpiration {
+  /**
+   * Expire a single fact by UUID.
+   * Sets expired_at timestamp on the fact.
+   * @param groupId - Group ID the fact belongs to
+   * @param uuid - UUID of the fact to expire
+   */
+  expire(groupId: string, uuid: string): Promise<void>;
+
+  /**
+   * Expire facts matching a filter.
+   * @param groupId - Group ID to filter within
+   * @param filter - Expiration filter criteria
+   * @returns Number of facts expired
+   */
+  expireByFilter(groupId: string, filter: IExpirationFilter): Promise<number>;
+}
+
+/**
  * Complete memory repository interface.
  */
 export interface IMemoryRepository
@@ -124,3 +151,10 @@ export interface IMemoryRepository
 export interface IReadOnlyMemoryRepository
   extends IMemoryRepositoryReader,
     IMemoryRepositoryCapabilities {}
+
+/**
+ * Read-only memory repository with expiration support (e.g., Neo4j direct).
+ */
+export interface IReadOnlyMemoryRepositoryWithExpiration
+  extends IReadOnlyMemoryRepository,
+    IMemoryRepositoryExpiration {}

--- a/src/lib/domain/interfaces/dal/index.ts
+++ b/src/lib/domain/interfaces/dal/index.ts
@@ -16,6 +16,7 @@ export type {
   IMemoryQueryResult,
   ITaskQueryResult,
   OperationType,
+  IExpirationFilter,
 } from './types';
 
 export {
@@ -41,8 +42,10 @@ export type {
   IMemoryRepositoryReader,
   IMemoryRepositoryWriter,
   IMemoryRepositoryCapabilities,
+  IMemoryRepositoryExpiration,
   IMemoryRepository,
   IReadOnlyMemoryRepository,
+  IReadOnlyMemoryRepositoryWithExpiration,
 } from './IMemoryRepository';
 
 // Task Repository

--- a/src/lib/domain/interfaces/dal/types.ts
+++ b/src/lib/domain/interfaces/dal/types.ts
@@ -6,6 +6,7 @@
 
 import { IMemoryItem } from '../types/IMemoryResult';
 import { ITask } from '../types/ITask';
+import type { MemoryLifecycle } from '../types/IMemoryLifecycle';
 
 /**
  * Fields that can be used for sorting.
@@ -105,4 +106,16 @@ export function applyQueryDefaults(options?: IQueryOptions): IQueryOptions {
     ...DEFAULT_QUERY_OPTIONS,
     ...options,
   };
+}
+
+/**
+ * Filter criteria for expiring facts.
+ */
+export interface IExpirationFilter {
+  /** Filter by lifecycle tier */
+  readonly lifecycle?: MemoryLifecycle;
+  /** Expire facts older than this date */
+  readonly olderThan?: Date;
+  /** Filter by tags (all must match) */
+  readonly tags?: readonly string[];
 }

--- a/src/lib/domain/interfaces/types/IMemoryLifecycle.ts
+++ b/src/lib/domain/interfaces/types/IMemoryLifecycle.ts
@@ -1,0 +1,102 @@
+/**
+ * Memory Lifecycle Types
+ *
+ * Defines lifecycle tiers for memory facts, controlling retention and expiration.
+ *
+ * Tiers:
+ * - permanent: Never expires (e.g., project conventions, key decisions)
+ * - project: Lives for the project lifetime, no automatic expiration
+ * - session: Expires after 24h (e.g., session-captured work)
+ * - ephemeral: Expires after 1h (e.g., user prompts, transient context)
+ */
+
+/**
+ * Memory lifecycle tier.
+ */
+export type MemoryLifecycle = 'permanent' | 'project' | 'session' | 'ephemeral';
+
+/**
+ * All valid lifecycle values.
+ */
+export const LIFECYCLE_VALUES: readonly MemoryLifecycle[] = [
+  'permanent',
+  'project',
+  'session',
+  'ephemeral',
+] as const;
+
+/**
+ * Default TTL (in milliseconds) for each lifecycle tier.
+ * null means no automatic expiration.
+ */
+export const LIFECYCLE_DEFAULTS: Readonly<Record<MemoryLifecycle, number | null>> = {
+  permanent: null,
+  project: null,
+  session: 24 * 60 * 60 * 1000,   // 24 hours
+  ephemeral: 60 * 60 * 1000,       // 1 hour
+};
+
+/**
+ * Tag prefix used for lifecycle tags.
+ */
+const LIFECYCLE_TAG_PREFIX = 'lifecycle:';
+
+/**
+ * Resolve a lifecycle tier to its corresponding tag string.
+ *
+ * @param lifecycle - The lifecycle tier
+ * @returns Tag string, e.g. 'lifecycle:permanent'
+ */
+export function resolveLifecycleTag(lifecycle: MemoryLifecycle): string {
+  return `${LIFECYCLE_TAG_PREFIX}${lifecycle}`;
+}
+
+/**
+ * Parse the lifecycle tier from a tag array.
+ * Looks for tags matching 'lifecycle:<tier>'.
+ *
+ * @param tags - Array of tags to search
+ * @returns The lifecycle tier found, or 'project' as default
+ */
+export function parseLifecycleTag(tags: readonly string[]): MemoryLifecycle {
+  for (const tag of tags) {
+    if (tag.startsWith(LIFECYCLE_TAG_PREFIX)) {
+      const tier = tag.slice(LIFECYCLE_TAG_PREFIX.length) as MemoryLifecycle;
+      if (LIFECYCLE_VALUES.includes(tier)) {
+        return tier;
+      }
+    }
+  }
+  return 'project';
+}
+
+/**
+ * Check if a string is a valid MemoryLifecycle value.
+ *
+ * @param value - The string to check
+ * @returns true if valid lifecycle tier
+ */
+export function isValidLifecycle(value: string): value is MemoryLifecycle {
+  return LIFECYCLE_VALUES.includes(value as MemoryLifecycle);
+}
+
+/**
+ * Compute the expiration date for a lifecycle tier.
+ *
+ * @param lifecycle - The lifecycle tier
+ * @param ttlMs - Optional custom TTL override in milliseconds
+ * @param now - Optional reference time (defaults to current time)
+ * @returns Expiration Date, or null if the tier never expires
+ */
+export function computeExpiresAt(
+  lifecycle: MemoryLifecycle,
+  ttlMs?: number,
+  now?: Date
+): Date | null {
+  const ttl = ttlMs ?? LIFECYCLE_DEFAULTS[lifecycle];
+  if (ttl === null) {
+    return null;
+  }
+  const referenceTime = now ?? new Date();
+  return new Date(referenceTime.getTime() + ttl);
+}

--- a/src/lib/domain/interfaces/types/index.ts
+++ b/src/lib/domain/interfaces/types/index.ts
@@ -19,3 +19,12 @@ export {
   createPullRequest,
   createGitHubIssue,
 } from './IPullRequest';
+export {
+  MemoryLifecycle,
+  LIFECYCLE_VALUES,
+  LIFECYCLE_DEFAULTS,
+  resolveLifecycleTag,
+  parseLifecycleTag,
+  isValidLifecycle,
+  computeExpiresAt,
+} from './IMemoryLifecycle';

--- a/tests/unit/src/lib/domain/interfaces/types/IMemoryLifecycle.test.ts
+++ b/tests/unit/src/lib/domain/interfaces/types/IMemoryLifecycle.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for IMemoryLifecycle
+ *
+ * Tests lifecycle types, tag resolution, parsing, and expiration computation.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  LIFECYCLE_VALUES,
+  LIFECYCLE_DEFAULTS,
+  resolveLifecycleTag,
+  parseLifecycleTag,
+  isValidLifecycle,
+  computeExpiresAt,
+} from '../../../../../../../src/lib/domain/interfaces/types/IMemoryLifecycle';
+
+describe('IMemoryLifecycle', () => {
+  describe('LIFECYCLE_VALUES', () => {
+    it('should contain all four lifecycle tiers', () => {
+      assert.deepStrictEqual([...LIFECYCLE_VALUES], [
+        'permanent',
+        'project',
+        'session',
+        'ephemeral',
+      ]);
+    });
+  });
+
+  describe('LIFECYCLE_DEFAULTS', () => {
+    it('should have null TTL for permanent', () => {
+      assert.strictEqual(LIFECYCLE_DEFAULTS.permanent, null);
+    });
+
+    it('should have null TTL for project', () => {
+      assert.strictEqual(LIFECYCLE_DEFAULTS.project, null);
+    });
+
+    it('should have 24h TTL for session', () => {
+      assert.strictEqual(LIFECYCLE_DEFAULTS.session, 24 * 60 * 60 * 1000);
+    });
+
+    it('should have 1h TTL for ephemeral', () => {
+      assert.strictEqual(LIFECYCLE_DEFAULTS.ephemeral, 60 * 60 * 1000);
+    });
+  });
+
+  describe('resolveLifecycleTag()', () => {
+    it('should return lifecycle:permanent for permanent', () => {
+      assert.strictEqual(resolveLifecycleTag('permanent'), 'lifecycle:permanent');
+    });
+
+    it('should return lifecycle:project for project', () => {
+      assert.strictEqual(resolveLifecycleTag('project'), 'lifecycle:project');
+    });
+
+    it('should return lifecycle:session for session', () => {
+      assert.strictEqual(resolveLifecycleTag('session'), 'lifecycle:session');
+    });
+
+    it('should return lifecycle:ephemeral for ephemeral', () => {
+      assert.strictEqual(resolveLifecycleTag('ephemeral'), 'lifecycle:ephemeral');
+    });
+  });
+
+  describe('parseLifecycleTag()', () => {
+    it('should extract permanent from tags', () => {
+      assert.strictEqual(
+        parseLifecycleTag(['type:fact', 'lifecycle:permanent', 'source:user']),
+        'permanent'
+      );
+    });
+
+    it('should extract session from tags', () => {
+      assert.strictEqual(
+        parseLifecycleTag(['lifecycle:session']),
+        'session'
+      );
+    });
+
+    it('should extract ephemeral from tags', () => {
+      assert.strictEqual(
+        parseLifecycleTag(['lifecycle:ephemeral', 'type:prompt']),
+        'ephemeral'
+      );
+    });
+
+    it('should default to project when no lifecycle tag present', () => {
+      assert.strictEqual(
+        parseLifecycleTag(['type:fact', 'source:user']),
+        'project'
+      );
+    });
+
+    it('should default to project for empty tags array', () => {
+      assert.strictEqual(parseLifecycleTag([]), 'project');
+    });
+
+    it('should ignore invalid lifecycle values in tags', () => {
+      assert.strictEqual(
+        parseLifecycleTag(['lifecycle:invalid', 'lifecycle:unknown']),
+        'project'
+      );
+    });
+
+    it('should return first valid lifecycle when multiple present', () => {
+      assert.strictEqual(
+        parseLifecycleTag(['lifecycle:session', 'lifecycle:permanent']),
+        'session'
+      );
+    });
+  });
+
+  describe('isValidLifecycle()', () => {
+    it('should return true for permanent', () => {
+      assert.strictEqual(isValidLifecycle('permanent'), true);
+    });
+
+    it('should return true for project', () => {
+      assert.strictEqual(isValidLifecycle('project'), true);
+    });
+
+    it('should return true for session', () => {
+      assert.strictEqual(isValidLifecycle('session'), true);
+    });
+
+    it('should return true for ephemeral', () => {
+      assert.strictEqual(isValidLifecycle('ephemeral'), true);
+    });
+
+    it('should return false for invalid values', () => {
+      assert.strictEqual(isValidLifecycle('temporary'), false);
+      assert.strictEqual(isValidLifecycle(''), false);
+      assert.strictEqual(isValidLifecycle('PERMANENT'), false);
+    });
+  });
+
+  describe('computeExpiresAt()', () => {
+    const now = new Date('2026-01-31T12:00:00.000Z');
+
+    it('should return null for permanent lifecycle', () => {
+      assert.strictEqual(computeExpiresAt('permanent', undefined, now), null);
+    });
+
+    it('should return null for project lifecycle', () => {
+      assert.strictEqual(computeExpiresAt('project', undefined, now), null);
+    });
+
+    it('should return now + 24h for session lifecycle', () => {
+      const result = computeExpiresAt('session', undefined, now);
+      assert.ok(result);
+      const expected = new Date('2026-02-01T12:00:00.000Z');
+      assert.strictEqual(result.getTime(), expected.getTime());
+    });
+
+    it('should return now + 1h for ephemeral lifecycle', () => {
+      const result = computeExpiresAt('ephemeral', undefined, now);
+      assert.ok(result);
+      const expected = new Date('2026-01-31T13:00:00.000Z');
+      assert.strictEqual(result.getTime(), expected.getTime());
+    });
+
+    it('should use custom TTL when provided', () => {
+      const customTtl = 2 * 60 * 60 * 1000; // 2 hours
+      const result = computeExpiresAt('session', customTtl, now);
+      assert.ok(result);
+      const expected = new Date('2026-01-31T14:00:00.000Z');
+      assert.strictEqual(result.getTime(), expected.getTime());
+    });
+
+    it('should override null TTL with custom TTL for permanent', () => {
+      const customTtl = 7 * 24 * 60 * 60 * 1000; // 7 days
+      const result = computeExpiresAt('permanent', customTtl, now);
+      assert.ok(result);
+      const expected = new Date('2026-02-07T12:00:00.000Z');
+      assert.strictEqual(result.getTime(), expected.getTime());
+    });
+
+    it('should use current time when now is not provided', () => {
+      const before = Date.now();
+      const result = computeExpiresAt('ephemeral');
+      const after = Date.now();
+      assert.ok(result);
+      // Result should be approximately 1 hour from now
+      const oneHour = 60 * 60 * 1000;
+      assert.ok(result.getTime() >= before + oneHour);
+      assert.ok(result.getTime() <= after + oneHour);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `MemoryLifecycle` type with four tiers: `permanent`, `project`, `session`, `ephemeral`
- Add utility functions: `resolveLifecycleTag()`, `parseLifecycleTag()`, `isValidLifecycle()`, `computeExpiresAt()`
- Add `IExpirationFilter` interface for expiration query criteria
- Add `IMemoryRepositoryExpiration` interface with `expire()` and `expireByFilter()` methods
- Add `IReadOnlyMemoryRepositoryWithExpiration` composite interface
- Extend `IMemorySaveOptions` with `lifecycle` and `ttlMs` fields
- 28 unit tests covering all utility functions

## Test plan
- [x] All 28 lifecycle tests pass
- [x] Full test suite passes (1 pre-existing failure in `SessionContextFormatter` unrelated to these changes)
- [x] Lint passes
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Build succeeds

Closes #111
Part of #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory lifecycle management with four tiers (permanent, project, session, ephemeral) for controlling data retention.
  * Added time-to-live (TTL) configuration support for memory storage.
  * Added expiration filtering capabilities for memory repositories.

* **Tests**
  * Added comprehensive unit tests for memory lifecycle functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->