### PR TITLE
feat(memory): Implement repository expiration in Neo4j and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ Added domain types and interfaces for memory lifecycle tiers, enabling retention
 
 Part of Epic [#110](https://github.com/TonyCasey/lisa/issues/110)
 
+#### Repository Expiration Support ([#112](https://github.com/TonyCasey/lisa/issues/112))
+
+Implemented expiration methods in Neo4j and MCP repository layers.
+
+- Neo4j `expire()`: Sets `expired_at` via Cypher WRITE session
+- Neo4j `expireByFilter()`: Count-then-write approach (READ for count, WRITE for expiration) with lifecycle, date, and tag filters
+- MCP stubs: Throw descriptive errors since MCP does not support direct expiration
+- 13 unit tests covering Neo4j expiration and MCP stubs
+
 ---
 
 ## [2.12.0] - 2026-01-31

--- a/src/lib/infrastructure/dal/repositories/mcp/McpMemoryRepository.ts
+++ b/src/lib/infrastructure/dal/repositories/mcp/McpMemoryRepository.ts
@@ -8,9 +8,11 @@
 import type { IMemoryItem } from '../../../../domain/interfaces/types/IMemoryResult';
 import type {
   IMemoryRepository,
+  IMemoryRepositoryExpiration,
   IMemorySaveOptions,
   IQueryOptions,
   IMemoryQueryResult,
+  IExpirationFilter,
 } from '../../../../domain/interfaces/dal';
 import { applyQueryDefaults } from '../../../../domain/interfaces/dal';
 import { McpConnectionManager } from '../../connections/McpConnectionManager';
@@ -41,7 +43,7 @@ interface McpFact {
  * MCP Memory Repository implementation.
  * Full read/write support via Graphiti MCP.
  */
-export class McpMemoryRepository implements IMemoryRepository {
+export class McpMemoryRepository implements IMemoryRepository, IMemoryRepositoryExpiration {
   constructor(private readonly connection: McpConnectionManager) {}
 
   /**
@@ -162,6 +164,26 @@ export class McpMemoryRepository implements IMemoryRepository {
     }
 
     return results;
+  }
+
+  /**
+   * MCP does not support direct expiration.
+   * Expiration must be performed via Neo4j direct.
+   */
+  async expire(_groupId: string, _uuid: string): Promise<void> {
+    throw new Error(
+      'MCP does not support direct expiration. Use Neo4j repository instead.'
+    );
+  }
+
+  /**
+   * MCP does not support direct expiration by filter.
+   * Expiration must be performed via Neo4j direct.
+   */
+  async expireByFilter(_groupId: string, _filter: IExpirationFilter): Promise<number> {
+    throw new Error(
+      'MCP does not support direct expiration. Use Neo4j repository instead.'
+    );
   }
 
   /**

--- a/src/lib/infrastructure/dal/repositories/neo4j/Neo4jMemoryRepository.ts
+++ b/src/lib/infrastructure/dal/repositories/neo4j/Neo4jMemoryRepository.ts
@@ -7,11 +7,13 @@
 
 import type { IMemoryItem } from '../../../../domain/interfaces/types/IMemoryResult';
 import type {
-  IReadOnlyMemoryRepository,
+  IReadOnlyMemoryRepositoryWithExpiration,
   IQueryOptions,
   IMemoryQueryResult,
+  IExpirationFilter,
 } from '../../../../domain/interfaces/dal';
 import { applyQueryDefaults } from '../../../../domain/interfaces/dal';
+import { resolveLifecycleTag } from '../../../../domain/interfaces/types/IMemoryLifecycle';
 import { Neo4jConnectionManager } from '../../connections/Neo4jConnectionManager';
 
 /**
@@ -29,10 +31,17 @@ interface Neo4jFactRecord {
 }
 
 /**
- * Neo4j Memory Repository implementation.
- * Read-only: writes go through MCP for proper Graphiti ingestion.
+ * Neo4j count result from Cypher COUNT query.
  */
-export class Neo4jMemoryRepository implements IReadOnlyMemoryRepository {
+interface Neo4jCountRecord {
+  count: number;
+}
+
+/**
+ * Neo4j Memory Repository implementation.
+ * Read-only with expiration support: writes go through MCP for proper Graphiti ingestion.
+ */
+export class Neo4jMemoryRepository implements IReadOnlyMemoryRepositoryWithExpiration {
   constructor(private readonly connection: Neo4jConnectionManager) {}
 
   /**
@@ -160,6 +169,74 @@ export class Neo4jMemoryRepository implements IReadOnlyMemoryRepository {
       source: 'neo4j',
       hasMore: items.length === limit,
     };
+  }
+
+  /**
+   * Expire a single fact by UUID.
+   * Sets expired_at timestamp on the matching relationship.
+   */
+  async expire(groupId: string, uuid: string): Promise<void> {
+    const cypher = `
+      MATCH (s:Entity)-[r]->(t:Entity)
+      WHERE r.group_id = $groupId AND r.uuid = $uuid AND r.expired_at IS NULL
+      SET r.expired_at = datetime()
+    `;
+    await this.connection.write(cypher, { groupId, uuid });
+  }
+
+  /**
+   * Expire facts matching a filter.
+   * Uses count-then-write: READ session for count, WRITE session for expiration.
+   * @returns Number of facts expired
+   */
+  async expireByFilter(groupId: string, filter: IExpirationFilter): Promise<number> {
+    const whereClauses: string[] = [
+      `r.group_id = $groupId`,
+      `r.fact IS NOT NULL`,
+      `r.expired_at IS NULL`,
+    ];
+    const params: Record<string, unknown> = { groupId };
+
+    if (filter.lifecycle) {
+      const lifecycleTag = resolveLifecycleTag(filter.lifecycle);
+      whereClauses.push(`$lifecycleTag IN r.tags`);
+      params.lifecycleTag = lifecycleTag;
+    }
+
+    if (filter.olderThan) {
+      whereClauses.push(`r.created_at <= datetime($olderThan)`);
+      params.olderThan = filter.olderThan.toISOString();
+    }
+
+    if (filter.tags && filter.tags.length > 0) {
+      whereClauses.push(`ANY(tag IN $filterTags WHERE tag IN r.tags)`);
+      params.filterTags = [...filter.tags];
+    }
+
+    const whereClause = whereClauses.join(' AND ');
+
+    // Step 1: Count matching facts (READ session)
+    const countCypher = `
+      MATCH (s:Entity)-[r]->(t:Entity)
+      WHERE ${whereClause}
+      RETURN count(r) AS count
+    `;
+    const countResult = await this.connection.query<Neo4jCountRecord>(countCypher, params);
+    const count = countResult[0]?.count ?? 0;
+
+    if (count === 0) {
+      return 0;
+    }
+
+    // Step 2: Expire matching facts (WRITE session)
+    const expireCypher = `
+      MATCH (s:Entity)-[r]->(t:Entity)
+      WHERE ${whereClause}
+      SET r.expired_at = datetime()
+    `;
+    await this.connection.write(expireCypher, params);
+
+    return count;
   }
 
   /**

--- a/tests/unit/src/lib/infrastructure/dal/repositories/mcp/McpMemoryRepository.expire.test.ts
+++ b/tests/unit/src/lib/infrastructure/dal/repositories/mcp/McpMemoryRepository.expire.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Tests for McpMemoryRepository expiration stubs.
+ *
+ * Verifies that MCP correctly throws for unsupported expiration operations.
+ */
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { McpMemoryRepository } from '../../../../../../../../src/lib/infrastructure/dal/repositories/mcp/McpMemoryRepository';
+import type { McpConnectionManager } from '../../../../../../../../src/lib/infrastructure/dal/connections/McpConnectionManager';
+
+function createMockConnection(): McpConnectionManager {
+  return {
+    call: mock.fn(async () => ({})),
+    connect: mock.fn(async () => undefined),
+    disconnect: mock.fn(async () => undefined),
+    isConnected: mock.fn(async () => true),
+    getConfig: mock.fn(() => ({})),
+  } as unknown as McpConnectionManager;
+}
+
+describe('McpMemoryRepository - expire', () => {
+  let repo: McpMemoryRepository;
+
+  beforeEach(() => {
+    const mockConnection = createMockConnection();
+    repo = new McpMemoryRepository(mockConnection);
+  });
+
+  describe('expire()', () => {
+    it('should throw error indicating MCP does not support expiration', async () => {
+      await assert.rejects(
+        () => repo.expire('group-1', 'uuid-abc'),
+        { message: 'MCP does not support direct expiration. Use Neo4j repository instead.' }
+      );
+    });
+  });
+
+  describe('expireByFilter()', () => {
+    it('should throw error indicating MCP does not support expiration', async () => {
+      await assert.rejects(
+        () => repo.expireByFilter('group-1', { lifecycle: 'session' }),
+        { message: 'MCP does not support direct expiration. Use Neo4j repository instead.' }
+      );
+    });
+  });
+});

--- a/tests/unit/src/lib/infrastructure/dal/repositories/neo4j/Neo4jMemoryRepository.expire.test.ts
+++ b/tests/unit/src/lib/infrastructure/dal/repositories/neo4j/Neo4jMemoryRepository.expire.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for Neo4jMemoryRepository expiration methods.
+ *
+ * Tests expire() and expireByFilter() using mocked Neo4j connection.
+ */
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { Neo4jMemoryRepository } from '../../../../../../../../src/lib/infrastructure/dal/repositories/neo4j/Neo4jMemoryRepository';
+import type { Neo4jConnectionManager } from '../../../../../../../../src/lib/infrastructure/dal/connections/Neo4jConnectionManager';
+
+function createMockConnection(): Neo4jConnectionManager {
+  return {
+    query: mock.fn(async () => []),
+    write: mock.fn(async () => undefined),
+    connect: mock.fn(async () => undefined),
+    disconnect: mock.fn(async () => undefined),
+    isConnected: mock.fn(async () => true),
+    getConfig: mock.fn(() => ({
+      uri: 'bolt://localhost:7687',
+      username: 'neo4j',
+      password: 'test',
+    })),
+    execute: mock.fn(async () => []),
+    getDriver: mock.fn(() => null),
+  } as unknown as Neo4jConnectionManager;
+}
+
+describe('Neo4jMemoryRepository - expire', () => {
+  let repo: Neo4jMemoryRepository;
+  let mockConnection: Neo4jConnectionManager;
+
+  beforeEach(() => {
+    mockConnection = createMockConnection();
+    repo = new Neo4jMemoryRepository(mockConnection);
+  });
+
+  describe('expire()', () => {
+    it('should call write with correct Cypher and params', async () => {
+      await repo.expire('group-1', 'uuid-abc');
+
+      const writeFn = mockConnection.write as ReturnType<typeof mock.fn>;
+      assert.strictEqual(writeFn.mock.calls.length, 1);
+
+      const [cypher, params] = writeFn.mock.calls[0].arguments;
+      assert.ok(cypher.includes('r.group_id = $groupId'));
+      assert.ok(cypher.includes('r.uuid = $uuid'));
+      assert.ok(cypher.includes('r.expired_at IS NULL'));
+      assert.ok(cypher.includes('SET r.expired_at = datetime()'));
+      assert.deepStrictEqual(params, { groupId: 'group-1', uuid: 'uuid-abc' });
+    });
+
+    it('should propagate errors from connection.write', async () => {
+      (mockConnection.write as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => { throw new Error('Connection failed'); }
+      );
+
+      await assert.rejects(
+        () => repo.expire('group-1', 'uuid-abc'),
+        { message: 'Connection failed' }
+      );
+    });
+  });
+
+  describe('expireByFilter()', () => {
+    it('should return 0 when no facts match', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 0 }]
+      );
+
+      const result = await repo.expireByFilter('group-1', {});
+      assert.strictEqual(result, 0);
+
+      // Should not call write when count is 0
+      const writeFn = mockConnection.write as ReturnType<typeof mock.fn>;
+      assert.strictEqual(writeFn.mock.calls.length, 0);
+    });
+
+    it('should count and then expire matching facts', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 5 }]
+      );
+
+      const result = await repo.expireByFilter('group-1', {});
+      assert.strictEqual(result, 5);
+
+      // Should call query for count, then write for expiration
+      const queryFn = mockConnection.query as ReturnType<typeof mock.fn>;
+      const writeFn = mockConnection.write as ReturnType<typeof mock.fn>;
+      assert.strictEqual(queryFn.mock.calls.length, 1);
+      assert.strictEqual(writeFn.mock.calls.length, 1);
+    });
+
+    it('should filter by lifecycle tag', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 3 }]
+      );
+
+      await repo.expireByFilter('group-1', { lifecycle: 'session' });
+
+      const queryFn = mockConnection.query as ReturnType<typeof mock.fn>;
+      const [cypher, params] = queryFn.mock.calls[0].arguments;
+      assert.ok(cypher.includes('$lifecycleTag IN r.tags'));
+      assert.strictEqual(params.lifecycleTag, 'lifecycle:session');
+    });
+
+    it('should filter by olderThan date', async () => {
+      const cutoff = new Date('2026-01-30T00:00:00.000Z');
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 2 }]
+      );
+
+      await repo.expireByFilter('group-1', { olderThan: cutoff });
+
+      const queryFn = mockConnection.query as ReturnType<typeof mock.fn>;
+      const [cypher, params] = queryFn.mock.calls[0].arguments;
+      assert.ok(cypher.includes('r.created_at <= datetime($olderThan)'));
+      assert.strictEqual(params.olderThan, '2026-01-30T00:00:00.000Z');
+    });
+
+    it('should filter by tags', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 1 }]
+      );
+
+      await repo.expireByFilter('group-1', { tags: ['type:prompt', 'source:user'] });
+
+      const queryFn = mockConnection.query as ReturnType<typeof mock.fn>;
+      const [cypher, params] = queryFn.mock.calls[0].arguments;
+      assert.ok(cypher.includes('ANY(tag IN $filterTags WHERE tag IN r.tags)'));
+      assert.deepStrictEqual(params.filterTags, ['type:prompt', 'source:user']);
+    });
+
+    it('should combine all filter criteria', async () => {
+      const cutoff = new Date('2026-01-30T00:00:00.000Z');
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 4 }]
+      );
+
+      await repo.expireByFilter('group-1', {
+        lifecycle: 'ephemeral',
+        olderThan: cutoff,
+        tags: ['type:prompt'],
+      });
+
+      const queryFn = mockConnection.query as ReturnType<typeof mock.fn>;
+      const [cypher, params] = queryFn.mock.calls[0].arguments;
+
+      // All clauses present
+      assert.ok(cypher.includes('r.group_id = $groupId'));
+      assert.ok(cypher.includes('r.expired_at IS NULL'));
+      assert.ok(cypher.includes('$lifecycleTag IN r.tags'));
+      assert.ok(cypher.includes('r.created_at <= datetime($olderThan)'));
+      assert.ok(cypher.includes('ANY(tag IN $filterTags WHERE tag IN r.tags)'));
+
+      assert.strictEqual(params.groupId, 'group-1');
+      assert.strictEqual(params.lifecycleTag, 'lifecycle:ephemeral');
+      assert.strictEqual(params.olderThan, '2026-01-30T00:00:00.000Z');
+      assert.deepStrictEqual(params.filterTags, ['type:prompt']);
+    });
+
+    it('should use same WHERE clause for count and expire queries', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => [{ count: 2 }]
+      );
+
+      await repo.expireByFilter('group-1', { lifecycle: 'session' });
+
+      const queryFn = mockConnection.query as ReturnType<typeof mock.fn>;
+      const writeFn = mockConnection.write as ReturnType<typeof mock.fn>;
+
+      const [countCypher] = queryFn.mock.calls[0].arguments;
+      const [expireCypher] = writeFn.mock.calls[0].arguments;
+
+      // Both should contain the same WHERE clause structure
+      assert.ok(countCypher.includes('r.group_id = $groupId'));
+      assert.ok(expireCypher.includes('r.group_id = $groupId'));
+      assert.ok(countCypher.includes('$lifecycleTag IN r.tags'));
+      assert.ok(expireCypher.includes('$lifecycleTag IN r.tags'));
+
+      // Count query should have COUNT, expire should have SET
+      assert.ok(countCypher.includes('count(r) AS count'));
+      assert.ok(expireCypher.includes('SET r.expired_at = datetime()'));
+    });
+
+    it('should propagate errors from connection.query', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => { throw new Error('Query failed'); }
+      );
+
+      await assert.rejects(
+        () => repo.expireByFilter('group-1', {}),
+        { message: 'Query failed' }
+      );
+    });
+
+    it('should handle empty query result gracefully', async () => {
+      (mockConnection.query as ReturnType<typeof mock.fn>).mock.mockImplementation(
+        async () => []
+      );
+
+      const result = await repo.expireByFilter('group-1', {});
+      assert.strictEqual(result, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `expire()` to Neo4j repository: sets `expired_at` via Cypher WRITE session
- Add `expireByFilter()` to Neo4j repository: count-then-write approach with lifecycle, date, and tag filters
- Add MCP expiration stubs that throw descriptive errors (MCP doesn't support direct expiration)
- 13 unit tests covering all expiration scenarios

## Test plan
- [x] 13 new expiration tests pass (10 Neo4j, 3 MCP)
- [x] Full test suite passes (1 pre-existing failure unrelated)
- [x] Lint passes
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Build succeeds

Closes #112
Part of #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expire individual memory items by ID.
  * Bulk expire items using filters: lifecycle stage, creation date, and custom tags.
  * Limitation: MCP repositories do not support direct expiration; use Neo4j repositories instead.

* **Tests**
  * Comprehensive unit test coverage for all expiration operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->