### PR TITLE
feat(memory): Add lifecycle methods to MemoryService and update handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ Implemented expiration methods in Neo4j and MCP repository layers.
 - MCP stubs: Throw descriptive errors since MCP does not support direct expiration
 - 13 unit tests covering Neo4j expiration and MCP stubs
 
+#### Service Layer Lifecycle Support ([#113](https://github.com/TonyCasey/lisa/issues/113))
+
+Added lifecycle-aware methods to the MemoryService and updated handlers to use lifecycle tagging.
+
+- `addFactWithLifecycle()`: Enriches tags with `lifecycle:<tier>` tag, delegates to `addFact()`
+- `expireFact()`: Routes to Neo4j repository's `expire()` via DAL router
+- `cleanupExpired()`: Expires session facts >24h and ephemeral facts >1h
+- `SessionStopHandler`: Now saves facts with `lifecycle: 'session'` via `addFactWithLifecycle()`
+- `PromptSubmitHandler`: Now saves prompts with `lifecycle: 'ephemeral'` via `addFactWithLifecycle()`
+- Extended `IMemoryWriter` interface with three new lifecycle methods
+- 10 new service-level tests, updated 5 existing handler tests
+
 ---
 
 ## [2.12.0] - 2026-01-31

--- a/src/lib/application/handlers/PromptSubmitHandler.ts
+++ b/src/lib/application/handlers/PromptSubmitHandler.ts
@@ -90,12 +90,12 @@ export class PromptSubmitHandler implements IRequestHandler<PromptSubmitRequest,
     // Truncate long prompts
     const truncatedContent = this.truncate(request.content, 200);
 
-    // Add to memory (fire-and-forget style - don't block on errors)
+    // Add to memory with ephemeral lifecycle (fire-and-forget style)
     try {
-      await this.memory.addFact(
+      await this.memory.addFactWithLifecycle(
         this.context.groupId,
         `User prompt at ${request.timestamp}: ${truncatedContent}`,
-        ['type:prompt']
+        { lifecycle: 'ephemeral', tags: ['type:prompt'] }
       );
     } catch {
       // Silently ignore errors - don't block user experience

--- a/src/lib/application/handlers/SessionStopHandler.ts
+++ b/src/lib/application/handlers/SessionStopHandler.ts
@@ -95,8 +95,13 @@ export class SessionStopHandler implements IRequestHandler<SessionStopRequest, I
       };
     }
 
-    // Save captured facts to memory
-    await this.memory.saveMemory(this.context.groupId, captured.facts);
+    // Save captured facts to memory with session lifecycle
+    for (const fact of captured.facts) {
+      await this.memory.addFactWithLifecycle(this.context.groupId, fact, {
+        lifecycle: 'session',
+        tags: ['type:session-capture'],
+      });
+    }
 
     // Emit internal event for any listeners
     await this.events.emit({

--- a/src/lib/domain/interfaces/IMemoryService.ts
+++ b/src/lib/domain/interfaces/IMemoryService.ts
@@ -1,4 +1,5 @@
 import type { IMemoryResult, IMemoryItem } from './types';
+import type { IMemorySaveOptions } from './dal/IMemoryRepository';
 
 /**
  * Options for date-filtered memory queries.
@@ -75,6 +76,35 @@ export interface IMemoryWriter {
    * @param tags - Optional tags for the fact
    */
   addFact(groupId: string, fact: string, tags?: readonly string[]): Promise<void>;
+
+  /**
+   * Add a fact with lifecycle metadata.
+   * Enriches tags with lifecycle:<tier> tag and delegates to addFact.
+   * @param groupId - Group ID to save to
+   * @param fact - Fact to add
+   * @param options - Save options including lifecycle and TTL
+   */
+  addFactWithLifecycle(
+    groupId: string,
+    fact: string,
+    options: IMemorySaveOptions
+  ): Promise<void>;
+
+  /**
+   * Expire a single fact by UUID.
+   * Routes to Neo4j repository for direct Cypher expiration.
+   * @param groupId - Group ID the fact belongs to
+   * @param uuid - UUID of the fact to expire
+   */
+  expireFact(groupId: string, uuid: string): Promise<void>;
+
+  /**
+   * Clean up expired facts based on lifecycle TTL defaults.
+   * Expires session facts older than 24h and ephemeral facts older than 1h.
+   * @param groupId - Group ID to clean up
+   * @returns Number of facts expired
+   */
+  cleanupExpired(groupId: string): Promise<number>;
 }
 
 /**

--- a/src/lib/domain/interfaces/index.ts
+++ b/src/lib/domain/interfaces/index.ts
@@ -6,6 +6,7 @@
 // Service interfaces
 export { ILisaContext } from './ILisaContext';
 export { IMemoryReader, IMemoryWriter, IMemoryService, IMemoryDateOptions } from './IMemoryService';
+export type { IMemorySaveOptions } from './dal/IMemoryRepository';
 export { ITaskReader, ITaskWriter, ITaskService } from './ITaskService';
 export { IMcpClient } from './IMcpClient';
 export { ISessionCaptureService } from './ISessionCaptureService';

--- a/src/lib/infrastructure/services/MemoryService.ts
+++ b/src/lib/infrastructure/services/MemoryService.ts
@@ -7,6 +7,7 @@ import type {
   IMemoryResultBuilder,
   IStructuredLogger,
   ILogContext,
+  IMemorySaveOptions,
 } from '../../domain';
 import {
   createMemoryResultBuilder,
@@ -15,8 +16,10 @@ import {
   isCancellationError,
   LogEvents,
 } from '../../domain';
+import { resolveLifecycleTag, LIFECYCLE_DEFAULTS } from '../../domain/interfaces/types/IMemoryLifecycle';
 import { ContextDetector } from '../context';
 import type { IRepositoryRouter } from '../../domain/interfaces/dal';
+import type { IMemoryRepositoryExpiration } from '../../domain/interfaces/dal';
 import { NullLogger } from '../logging';
 
 const MEMORY_LOAD_TIMEOUT_MS = 5000;
@@ -337,6 +340,84 @@ export class MemoryService implements IMemoryService {
       tags: [...tags],
     });
     completeOperation({ data: { backend: 'mcp', factLength: fact.length } });
+  }
+
+  /**
+   * Add a fact with lifecycle metadata.
+   * Enriches tags with lifecycle:<tier> tag and delegates to addFact.
+   */
+  async addFactWithLifecycle(
+    groupId: string,
+    fact: string,
+    options: IMemorySaveOptions
+  ): Promise<void> {
+    const lifecycle = options.lifecycle ?? 'project';
+    const lifecycleTag = resolveLifecycleTag(lifecycle);
+
+    // Merge lifecycle tag with existing tags
+    const existingTags = options.tags ? [...options.tags] : [];
+    if (!existingTags.includes(lifecycleTag)) {
+      existingTags.push(lifecycleTag);
+    }
+
+    await this.addFact(groupId, fact, existingTags);
+  }
+
+  /**
+   * Expire a single fact by UUID.
+   * Routes to a repository that supports expiration.
+   */
+  async expireFact(groupId: string, uuid: string): Promise<void> {
+    if (!this.router) {
+      throw new Error('Expiration requires a DAL router with Neo4j support');
+    }
+
+    const repo = this.router.getMemoryRepository('list');
+    if (!('expire' in repo)) {
+      throw new Error('Memory repository does not support expiration');
+    }
+    await (repo as unknown as IMemoryRepositoryExpiration).expire(groupId, uuid);
+  }
+
+  /**
+   * Clean up expired facts based on lifecycle TTL defaults.
+   * Expires session facts older than 24h and ephemeral facts older than 1h.
+   */
+  async cleanupExpired(groupId: string): Promise<number> {
+    if (!this.router) {
+      throw new Error('Cleanup requires a DAL router with Neo4j support');
+    }
+
+    const repo = this.router.getMemoryRepository('list');
+    if (!('expireByFilter' in repo)) {
+      throw new Error('Memory repository does not support expiration');
+    }
+    const expirationRepo = repo as unknown as IMemoryRepositoryExpiration;
+
+    const now = new Date();
+    let totalExpired = 0;
+
+    // Expire session facts older than their TTL (24h)
+    const sessionTtl = LIFECYCLE_DEFAULTS.session;
+    if (sessionTtl !== null) {
+      const sessionCutoff = new Date(now.getTime() - sessionTtl);
+      totalExpired += await expirationRepo.expireByFilter(groupId, {
+        lifecycle: 'session',
+        olderThan: sessionCutoff,
+      });
+    }
+
+    // Expire ephemeral facts older than their TTL (1h)
+    const ephemeralTtl = LIFECYCLE_DEFAULTS.ephemeral;
+    if (ephemeralTtl !== null) {
+      const ephemeralCutoff = new Date(now.getTime() - ephemeralTtl);
+      totalExpired += await expirationRepo.expireByFilter(groupId, {
+        lifecycle: 'ephemeral',
+        olderThan: ephemeralCutoff,
+      });
+    }
+
+    return totalExpired;
   }
 
   /**

--- a/tests/unit/src/lib/application/handlers/PromptSubmitHandler.test.ts
+++ b/tests/unit/src/lib/application/handlers/PromptSubmitHandler.test.ts
@@ -43,6 +43,9 @@ function createMockContext(overrides: Partial<ILisaContext> = {}): ILisaContext 
 function createMockMemoryService(overrides: Partial<IMemoryService> = {}): IMemoryService {
   return {
     addFact: async () => {},
+    addFactWithLifecycle: async () => {},
+    expireFact: async () => {},
+    cleanupExpired: async () => 0,
     search: async () => [],
     listRecent: async () => [],
     loadMemory: async () => ({
@@ -178,11 +181,11 @@ describe('PromptSubmitHandler', () => {
   });
 
   describe('memory storage', () => {
-    it('should add prompt to memory with truncated content', async () => {
-      let addedFact: { groupId: string; fact: string; tags: readonly string[] } | undefined;
+    it('should add prompt to memory with ephemeral lifecycle', async () => {
+      let addedFact: { groupId: string; fact: string; options: unknown } | undefined;
       const mockMemory = createMockMemoryService({
-        addFact: async (groupId, fact, tags) => {
-          addedFact = { groupId, fact, tags: tags || [] };
+        addFactWithLifecycle: async (groupId, fact, options) => {
+          addedFact = { groupId, fact, options };
         },
       });
 
@@ -198,13 +201,15 @@ describe('PromptSubmitHandler', () => {
       assert.strictEqual(addedFact.groupId, 'test-group');
       assert.ok(addedFact.fact.includes('User prompt at 2024-01-15T10:00:00.000Z'));
       assert.ok(addedFact.fact.includes('Test prompt content'));
-      assert.deepStrictEqual(addedFact.tags, ['type:prompt']);
+      const opts = addedFact.options as { lifecycle: string; tags: string[] };
+      assert.strictEqual(opts.lifecycle, 'ephemeral');
+      assert.deepStrictEqual(opts.tags, ['type:prompt']);
     });
 
     it('should truncate long prompts to 200 characters', async () => {
       let addedFact: string | undefined;
       const mockMemory = createMockMemoryService({
-        addFact: async (_groupId, fact) => {
+        addFactWithLifecycle: async (_groupId, fact) => {
           addedFact = fact;
         },
       });
@@ -227,7 +232,7 @@ describe('PromptSubmitHandler', () => {
     it('should not truncate short prompts', async () => {
       let addedFact: string | undefined;
       const mockMemory = createMockMemoryService({
-        addFact: async (_groupId, fact) => {
+        addFactWithLifecycle: async (_groupId, fact) => {
           addedFact = fact;
         },
       });
@@ -248,7 +253,7 @@ describe('PromptSubmitHandler', () => {
 
     it('should silently ignore memory errors', async () => {
       const mockMemory = createMockMemoryService({
-        addFact: async () => {
+        addFactWithLifecycle: async () => {
           throw new Error('Memory service unavailable');
         },
       });

--- a/tests/unit/src/lib/application/handlers/SessionStopHandler.test.ts
+++ b/tests/unit/src/lib/application/handlers/SessionStopHandler.test.ts
@@ -46,6 +46,9 @@ function createMockMemory(overrides: Partial<IMemoryService> = {}): IMemoryServi
     searchFacts: async () => [],
     saveMemory: async () => {},
     addFact: async () => {},
+    addFactWithLifecycle: async () => {},
+    expireFact: async () => {},
+    cleanupExpired: async () => 0,
     ...overrides,
   };
 }
@@ -198,7 +201,7 @@ describe('SessionStopHandler', () => {
 
     it('should handle memory save errors gracefully', async () => {
       const failingMemory = createMockMemory({
-        saveMemory: async () => {
+        addFactWithLifecycle: async () => {
           throw new Error('Memory unavailable');
         },
       });
@@ -219,12 +222,14 @@ describe('SessionStopHandler', () => {
       );
     });
 
-    it('should capture facts and save to memory', async () => {
-      let savedFacts: string[] = [];
+    it('should capture facts and save to memory with session lifecycle', async () => {
+      const savedFacts: string[] = [];
+      const savedOptions: unknown[] = [];
       const context = createMockContext();
       const memory = createMockMemory({
-        saveMemory: async (_groupId, facts) => {
-          savedFacts = [...facts];
+        addFactWithLifecycle: async (_groupId, fact, options) => {
+          savedFacts.push(fact);
+          savedOptions.push(options);
         },
       });
       const sessionCapture = createMockSessionCapture({
@@ -252,6 +257,12 @@ describe('SessionStopHandler', () => {
       assert.strictEqual(result.skipped, false);
       assert.ok(result.message.includes('2'));
       assert.deepStrictEqual(savedFacts, ['Implemented feature X', 'Fixed bug Y']);
+      // Verify lifecycle options were passed
+      for (const opts of savedOptions) {
+        const o = opts as { lifecycle: string; tags: string[] };
+        assert.strictEqual(o.lifecycle, 'session');
+        assert.ok(o.tags.includes('type:session-capture'));
+      }
     });
 
     it('should skip when no facts captured', async () => {

--- a/tests/unit/src/lib/infrastructure/services/MemoryService.lifecycle.test.ts
+++ b/tests/unit/src/lib/infrastructure/services/MemoryService.lifecycle.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Tests for MemoryService lifecycle methods.
+ *
+ * Tests addFactWithLifecycle, expireFact, and cleanupExpired.
+ */
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert';
+import { MemoryService } from '../../../../../../src/lib/infrastructure/services/MemoryService';
+import type { IMcpClient, ILogger } from '../../../../../../src/lib/domain';
+import type { IRepositoryRouter } from '../../../../../../src/lib/domain/interfaces/dal';
+
+function createMockMcpClient(): IMcpClient {
+  return {
+    call: mock.fn(async () => [{}]),
+    getSessionId: mock.fn(() => 'test-session'),
+    connect: mock.fn(async () => undefined),
+    disconnect: mock.fn(async () => undefined),
+    isConnected: mock.fn(async () => true),
+  } as unknown as IMcpClient;
+}
+
+function createMockLogger(): ILogger {
+  const logger: ILogger = {
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    fatal: () => {},
+    child: () => logger,
+    isLevelEnabled: () => true,
+    logEvent: () => {},
+    logEventWarn: () => {},
+    startOperation: () => () => {},
+  } as unknown as ILogger;
+  return logger;
+}
+
+function createMockRouter(overrides: Partial<IRepositoryRouter> = {}): IRepositoryRouter {
+  const mockRepo = {
+    findByGroupIds: mock.fn(async () => ({ items: [], source: 'neo4j' as const, hasMore: false })),
+    search: mock.fn(async () => ({ items: [], source: 'neo4j' as const, hasMore: false })),
+    findByTags: mock.fn(async () => ({ items: [], source: 'neo4j' as const, hasMore: false })),
+    supportsSemanticSearch: () => false,
+    supportsDateOrdering: () => true,
+    supportsWrite: () => false,
+    expire: mock.fn(async () => undefined),
+    expireByFilter: mock.fn(async () => 3),
+    save: mock.fn(async () => ({ name: 'test', fact: 'test', created_at: new Date().toISOString() })),
+  };
+
+  return {
+    getMemoryRepository: mock.fn(() => mockRepo),
+    getTaskRepository: mock.fn(() => ({})),
+    getPullRequestRepository: mock.fn(() => ({})),
+    ...overrides,
+  } as unknown as IRepositoryRouter;
+}
+
+describe('MemoryService - lifecycle', () => {
+  let mcp: IMcpClient;
+  let logger: ILogger;
+
+  beforeEach(() => {
+    mcp = createMockMcpClient();
+    logger = createMockLogger();
+  });
+
+  describe('addFactWithLifecycle()', () => {
+    it('should add lifecycle tag to existing tags', async () => {
+      const callFn = mcp.call as ReturnType<typeof mock.fn>;
+      const service = new MemoryService(mcp, undefined, logger);
+
+      await service.addFactWithLifecycle('group-1', 'Test fact', {
+        lifecycle: 'session',
+        tags: ['type:test'],
+      });
+
+      assert.strictEqual(callFn.mock.calls.length, 1);
+      const [, params] = callFn.mock.calls[0].arguments;
+      const p = params as { tags: string[] };
+      assert.ok(p.tags.includes('lifecycle:session'));
+      assert.ok(p.tags.includes('type:test'));
+    });
+
+    it('should default to project lifecycle when not specified', async () => {
+      const callFn = mcp.call as ReturnType<typeof mock.fn>;
+      const service = new MemoryService(mcp, undefined, logger);
+
+      await service.addFactWithLifecycle('group-1', 'Test fact', {});
+
+      assert.strictEqual(callFn.mock.calls.length, 1);
+      const [, params] = callFn.mock.calls[0].arguments;
+      const p = params as { tags: string[] };
+      assert.ok(p.tags.includes('lifecycle:project'));
+    });
+
+    it('should not duplicate lifecycle tag if already present', async () => {
+      const callFn = mcp.call as ReturnType<typeof mock.fn>;
+      const service = new MemoryService(mcp, undefined, logger);
+
+      await service.addFactWithLifecycle('group-1', 'Test fact', {
+        lifecycle: 'ephemeral',
+        tags: ['lifecycle:ephemeral', 'type:prompt'],
+      });
+
+      assert.strictEqual(callFn.mock.calls.length, 1);
+      const [, params] = callFn.mock.calls[0].arguments;
+      const p = params as { tags: string[] };
+      const lifecycleTags = p.tags.filter((t: string) => t === 'lifecycle:ephemeral');
+      assert.strictEqual(lifecycleTags.length, 1, 'Should not duplicate lifecycle tag');
+    });
+
+    it('should work with empty tags', async () => {
+      const callFn = mcp.call as ReturnType<typeof mock.fn>;
+      const service = new MemoryService(mcp, undefined, logger);
+
+      await service.addFactWithLifecycle('group-1', 'Test fact', {
+        lifecycle: 'permanent',
+      });
+
+      assert.strictEqual(callFn.mock.calls.length, 1);
+      const [, params] = callFn.mock.calls[0].arguments;
+      const p = params as { tags: string[] };
+      assert.ok(p.tags.includes('lifecycle:permanent'));
+    });
+  });
+
+  describe('expireFact()', () => {
+    it('should throw without a router', async () => {
+      const service = new MemoryService(mcp, undefined, logger);
+
+      await assert.rejects(
+        () => service.expireFact('group-1', 'uuid-abc'),
+        { message: 'Expiration requires a DAL router with Neo4j support' }
+      );
+    });
+
+    it('should call expire on the repository via router', async () => {
+      const router = createMockRouter();
+      const service = new MemoryService(mcp, router, logger);
+
+      await service.expireFact('group-1', 'uuid-abc');
+
+      const getRepoFn = router.getMemoryRepository as ReturnType<typeof mock.fn>;
+      assert.strictEqual(getRepoFn.mock.calls.length, 1);
+      assert.strictEqual(getRepoFn.mock.calls[0].arguments[0], 'list');
+    });
+
+    it('should throw when repository does not support expiration', async () => {
+      const repoWithoutExpire = {
+        findByGroupIds: mock.fn(async () => ({ items: [], source: 'mcp' as const })),
+        search: mock.fn(async () => ({ items: [], source: 'mcp' as const })),
+        findByTags: mock.fn(async () => ({ items: [], source: 'mcp' as const })),
+        supportsSemanticSearch: () => true,
+        supportsDateOrdering: () => true,
+        supportsWrite: () => true,
+      };
+      const router = createMockRouter({
+        getMemoryRepository: mock.fn(() => repoWithoutExpire),
+      } as unknown as Partial<IRepositoryRouter>);
+      const service = new MemoryService(mcp, router, logger);
+
+      await assert.rejects(
+        () => service.expireFact('group-1', 'uuid-abc'),
+        { message: 'Memory repository does not support expiration' }
+      );
+    });
+  });
+
+  describe('cleanupExpired()', () => {
+    it('should throw without a router', async () => {
+      const service = new MemoryService(mcp, undefined, logger);
+
+      await assert.rejects(
+        () => service.cleanupExpired('group-1'),
+        { message: 'Cleanup requires a DAL router with Neo4j support' }
+      );
+    });
+
+    it('should call expireByFilter for session and ephemeral tiers', async () => {
+      const mockRepo = {
+        findByGroupIds: mock.fn(async () => ({ items: [], source: 'neo4j' as const })),
+        search: mock.fn(async () => ({ items: [], source: 'neo4j' as const })),
+        findByTags: mock.fn(async () => ({ items: [], source: 'neo4j' as const })),
+        supportsSemanticSearch: () => false,
+        supportsDateOrdering: () => true,
+        supportsWrite: () => false,
+        expire: mock.fn(async () => undefined),
+        expireByFilter: mock.fn(async () => 2),
+      };
+      const router = createMockRouter({
+        getMemoryRepository: mock.fn(() => mockRepo),
+      } as unknown as Partial<IRepositoryRouter>);
+      const service = new MemoryService(mcp, router, logger);
+
+      const result = await service.cleanupExpired('group-1');
+
+      // Should call expireByFilter twice (once for session, once for ephemeral)
+      assert.strictEqual(mockRepo.expireByFilter.mock.calls.length, 2);
+
+      const [, filter1] = mockRepo.expireByFilter.mock.calls[0].arguments;
+      assert.strictEqual(filter1.lifecycle, 'session');
+      assert.ok(filter1.olderThan instanceof Date);
+
+      const [, filter2] = mockRepo.expireByFilter.mock.calls[1].arguments;
+      assert.strictEqual(filter2.lifecycle, 'ephemeral');
+      assert.ok(filter2.olderThan instanceof Date);
+
+      // Total expired should be sum of both calls (2 + 2 = 4)
+      assert.strictEqual(result, 4);
+    });
+
+    it('should return 0 when no facts expired', async () => {
+      const mockRepo = {
+        findByGroupIds: mock.fn(async () => ({ items: [], source: 'neo4j' as const })),
+        search: mock.fn(async () => ({ items: [], source: 'neo4j' as const })),
+        findByTags: mock.fn(async () => ({ items: [], source: 'neo4j' as const })),
+        supportsSemanticSearch: () => false,
+        supportsDateOrdering: () => true,
+        supportsWrite: () => false,
+        expire: mock.fn(async () => undefined),
+        expireByFilter: mock.fn(async () => 0),
+      };
+      const router = createMockRouter({
+        getMemoryRepository: mock.fn(() => mockRepo),
+      } as unknown as Partial<IRepositoryRouter>);
+      const service = new MemoryService(mcp, router, logger);
+
+      const result = await service.cleanupExpired('group-1');
+      assert.strictEqual(result, 0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `addFactWithLifecycle()` to `MemoryService`: enriches tags with `lifecycle:<tier>` tag, delegates to `addFact()`
- Add `expireFact()` to `MemoryService`: routes to Neo4j repository's `expire()` via DAL router
- Add `cleanupExpired()` to `MemoryService`: expires session facts >24h and ephemeral facts >1h
- Update `SessionStopHandler`: saves facts with `lifecycle: 'session'` via `addFactWithLifecycle()`
- Update `PromptSubmitHandler`: saves prompts with `lifecycle: 'ephemeral'` via `addFactWithLifecycle()`
- Extend `IMemoryWriter` interface with three new lifecycle methods
- Export `IMemorySaveOptions` from domain interfaces index

## Test plan
- [x] 10 new MemoryService lifecycle tests pass
- [x] All 43 lifecycle + handler tests pass
- [x] Full test suite passes (1 pre-existing failure unrelated)
- [x] Lint passes
- [x] TypeScript compiles (`tsc --noEmit`)
- [x] Build succeeds

Closes #113
Part of #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle-aware memory management with automatic cleanup of expired facts (session facts older than 24 hours and ephemeral facts older than 1 hour).
  * Session facts now tagged with session scope metadata.
  * Prompts now stored as temporary ephemeral entries.

* **Tests**
  * Added tests for lifecycle-based memory management functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->