### PR TITLE
feat(memory): Add quality and source tracking domain types (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Memory Quality & Source Tracking Domain Types ([#125](https://github.com/TonyCasey/lisa/issues/125))
+
+Added domain types and interfaces for fact quality tracking and provenance, enabling confidence scoring and source attribution for memory facts.
+
+- `ConfidenceLevel` type with five levels: `verified`, `high`, `medium`, `low`, `uncertain`
+- `SourceType` type with six source categories: `user-explicit`, `session-capture`, `prompt-capture`, `code-analysis`, `auto-inferred`, `external-sync`
+- Score mappings (`CONFIDENCE_SCORES`) and default confidence per source (`DEFAULT_CONFIDENCE`)
+- Utility functions: `resolveConfidenceTag()`, `parseConfidenceTag()`, `isValidConfidence()`, `confidenceToScore()`, `scoreToConfidence()`, `resolveSourceTag()`, `parseSourceTag()`, `isValidSource()`, `defaultConfidenceForSource()`
+- `IQualityFilter` and `IConflictGroup` interfaces for quality-based queries
+- `IMemoryRepositoryQuality` interface with `findByMinConfidence()` and `findConflicts()` methods
+- `IReadOnlyMemoryRepositoryWithQuality` composite interface
+- Extended `IMemorySaveOptions` with `confidence` and `sourceType` fields
+- Extended `IQueryOptions` with optional `quality` filter
+
+Part of Epic [#124](https://github.com/TonyCasey/lisa/issues/124)
+
 #### Memory Lifecycle Domain Types ([#111](https://github.com/TonyCasey/lisa/issues/111))
 
 Added domain types and interfaces for memory lifecycle tiers, enabling retention control and TTL-based expiration for memory facts.

--- a/src/lib/domain/interfaces/dal/IMemoryRepository.ts
+++ b/src/lib/domain/interfaces/dal/IMemoryRepository.ts
@@ -7,7 +7,8 @@
 
 import { IMemoryItem } from '../types/IMemoryResult';
 import type { MemoryLifecycle } from '../types/IMemoryLifecycle';
-import { IQueryOptions, IMemoryQueryResult, IExpirationFilter } from './types';
+import type { ConfidenceLevel, SourceType } from '../types/IMemoryQuality';
+import { IQueryOptions, IMemoryQueryResult, IExpirationFilter, IConflictGroup } from './types';
 
 /**
  * Options for saving memory.
@@ -21,6 +22,10 @@ export interface IMemorySaveOptions {
   readonly lifecycle?: MemoryLifecycle;
   /** Custom TTL override in milliseconds (overrides lifecycle default) */
   readonly ttlMs?: number;
+  /** Confidence level for the fact */
+  readonly confidence?: ConfidenceLevel;
+  /** Source type for provenance tracking */
+  readonly sourceType?: SourceType;
 }
 
 /**
@@ -138,6 +143,37 @@ export interface IMemoryRepositoryExpiration {
 }
 
 /**
+ * Quality operations for memory repositories.
+ * Separated interface since not all backends support quality queries.
+ */
+export interface IMemoryRepositoryQuality {
+  /**
+   * Find facts at or above a minimum confidence level.
+   * @param groupIds - Group IDs to search
+   * @param minLevel - Minimum confidence level (inclusive)
+   * @param options - Additional query options
+   */
+  findByMinConfidence(
+    groupIds: readonly string[],
+    minLevel: ConfidenceLevel,
+    options?: IQueryOptions
+  ): Promise<IMemoryQueryResult>;
+
+  /**
+   * Find groups of potentially conflicting facts.
+   * Detects facts sharing topic tags but with differing content.
+   * @param groupIds - Group IDs to search
+   * @param topic - Optional topic to filter conflicts by
+   * @param options - Additional query options
+   */
+  findConflicts(
+    groupIds: readonly string[],
+    topic?: string,
+    options?: IQueryOptions
+  ): Promise<readonly IConflictGroup[]>;
+}
+
+/**
  * Complete memory repository interface.
  */
 export interface IMemoryRepository
@@ -158,3 +194,10 @@ export interface IReadOnlyMemoryRepository
 export interface IReadOnlyMemoryRepositoryWithExpiration
   extends IReadOnlyMemoryRepository,
     IMemoryRepositoryExpiration {}
+
+/**
+ * Read-only memory repository with expiration and quality support.
+ */
+export interface IReadOnlyMemoryRepositoryWithQuality
+  extends IReadOnlyMemoryRepositoryWithExpiration,
+    IMemoryRepositoryQuality {}

--- a/src/lib/domain/interfaces/dal/index.ts
+++ b/src/lib/domain/interfaces/dal/index.ts
@@ -17,6 +17,8 @@ export type {
   ITaskQueryResult,
   OperationType,
   IExpirationFilter,
+  IQualityFilter,
+  IConflictGroup,
 } from './types';
 
 export {
@@ -43,9 +45,11 @@ export type {
   IMemoryRepositoryWriter,
   IMemoryRepositoryCapabilities,
   IMemoryRepositoryExpiration,
+  IMemoryRepositoryQuality,
   IMemoryRepository,
   IReadOnlyMemoryRepository,
   IReadOnlyMemoryRepositoryWithExpiration,
+  IReadOnlyMemoryRepositoryWithQuality,
 } from './IMemoryRepository';
 
 // Task Repository

--- a/src/lib/domain/interfaces/dal/types.ts
+++ b/src/lib/domain/interfaces/dal/types.ts
@@ -7,6 +7,7 @@
 import { IMemoryItem } from '../types/IMemoryResult';
 import { ITask } from '../types/ITask';
 import type { MemoryLifecycle } from '../types/IMemoryLifecycle';
+import type { ConfidenceLevel, SourceType } from '../types/IMemoryQuality';
 
 /**
  * Fields that can be used for sorting.
@@ -46,6 +47,8 @@ export interface IQueryOptions {
   readonly until?: Date;
   /** Include expired/invalidated facts */
   readonly includeExpired?: boolean;
+  /** Quality-based filtering */
+  readonly quality?: IQualityFilter;
 }
 
 /**
@@ -118,4 +121,28 @@ export interface IExpirationFilter {
   readonly olderThan?: Date;
   /** Filter by tags (all must match) */
   readonly tags?: readonly string[];
+}
+
+/**
+ * Filter criteria for quality-based queries.
+ */
+export interface IQualityFilter {
+  /** Minimum confidence level (inclusive) */
+  readonly minConfidence?: ConfidenceLevel;
+  /** Filter by source type */
+  readonly sourceType?: SourceType;
+  /** Only include facts marked as curated */
+  readonly curatedOnly?: boolean;
+}
+
+/**
+ * A group of potentially conflicting facts sharing a topic.
+ */
+export interface IConflictGroup {
+  /** Shared topic or tag that links these facts */
+  readonly topic: string;
+  /** The conflicting facts */
+  readonly facts: readonly IMemoryItem[];
+  /** When the conflict was detected */
+  readonly detectedAt: string;
 }

--- a/src/lib/domain/interfaces/types/IMemoryQuality.ts
+++ b/src/lib/domain/interfaces/types/IMemoryQuality.ts
@@ -1,0 +1,213 @@
+/**
+ * Memory Quality & Source Tracking Types
+ *
+ * Defines confidence levels, source types, and helper functions for
+ * tracking fact provenance and quality. Follows the same tag-based
+ * pattern as IMemoryLifecycle.
+ *
+ * Confidence levels:
+ * - verified: Confirmed by user, code check, or test (1.0)
+ * - high: User-stated or documented (0.8)
+ * - medium: Auto-captured, consistent with other facts (0.5)
+ * - low: Inferred or from low-fidelity source (0.3)
+ * - uncertain: Needs verification (0.1)
+ *
+ * Source types:
+ * - user-explicit: User directly stated via `lisa memory add`
+ * - session-capture: Extracted from session stop handler
+ * - prompt-capture: Captured from user prompt submit
+ * - code-analysis: Inferred from code inspection
+ * - auto-inferred: System-generated inference
+ * - external-sync: Synced from external system (Jira, GitHub, etc.)
+ */
+
+/**
+ * Confidence level for a memory fact.
+ */
+export type ConfidenceLevel = 'verified' | 'high' | 'medium' | 'low' | 'uncertain';
+
+/**
+ * All valid confidence levels, ordered from highest to lowest.
+ */
+export const CONFIDENCE_VALUES: readonly ConfidenceLevel[] = [
+  'verified',
+  'high',
+  'medium',
+  'low',
+  'uncertain',
+] as const;
+
+/**
+ * Numeric score for each confidence level (0.0 - 1.0).
+ */
+export const CONFIDENCE_SCORES: Readonly<Record<ConfidenceLevel, number>> = {
+  verified: 1.0,
+  high: 0.8,
+  medium: 0.5,
+  low: 0.3,
+  uncertain: 0.1,
+};
+
+/**
+ * Source type indicating where a fact originated.
+ */
+export type SourceType =
+  | 'user-explicit'
+  | 'session-capture'
+  | 'prompt-capture'
+  | 'code-analysis'
+  | 'auto-inferred'
+  | 'external-sync';
+
+/**
+ * All valid source types.
+ */
+export const SOURCE_VALUES: readonly SourceType[] = [
+  'user-explicit',
+  'session-capture',
+  'prompt-capture',
+  'code-analysis',
+  'auto-inferred',
+  'external-sync',
+] as const;
+
+/**
+ * Default confidence level assigned for each source type.
+ */
+export const DEFAULT_CONFIDENCE: Readonly<Record<SourceType, ConfidenceLevel>> = {
+  'user-explicit': 'high',
+  'session-capture': 'medium',
+  'prompt-capture': 'low',
+  'code-analysis': 'medium',
+  'auto-inferred': 'low',
+  'external-sync': 'medium',
+};
+
+/**
+ * Tag prefix used for confidence tags.
+ */
+const CONFIDENCE_TAG_PREFIX = 'confidence:';
+
+/**
+ * Tag prefix used for source tags.
+ */
+const SOURCE_TAG_PREFIX = 'source:';
+
+/**
+ * Resolve a confidence level to its corresponding tag string.
+ *
+ * @param level - The confidence level
+ * @returns Tag string, e.g. 'confidence:high'
+ */
+export function resolveConfidenceTag(level: ConfidenceLevel): string {
+  return `${CONFIDENCE_TAG_PREFIX}${level}`;
+}
+
+/**
+ * Parse the confidence level from a tag array.
+ * Looks for tags matching 'confidence:<level>'.
+ *
+ * @param tags - Array of tags to search
+ * @returns The confidence level found, or null if none present
+ */
+export function parseConfidenceTag(tags: readonly string[]): ConfidenceLevel | null {
+  for (const tag of tags) {
+    if (tag.startsWith(CONFIDENCE_TAG_PREFIX)) {
+      const level = tag.slice(CONFIDENCE_TAG_PREFIX.length) as ConfidenceLevel;
+      if (CONFIDENCE_VALUES.includes(level)) {
+        return level;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a string is a valid ConfidenceLevel value.
+ *
+ * @param value - The string to check
+ * @returns true if valid confidence level
+ */
+export function isValidConfidence(value: string): value is ConfidenceLevel {
+  return CONFIDENCE_VALUES.includes(value as ConfidenceLevel);
+}
+
+/**
+ * Convert a confidence level to its numeric score.
+ *
+ * @param level - The confidence level
+ * @returns Numeric score between 0.0 and 1.0
+ */
+export function confidenceToScore(level: ConfidenceLevel): number {
+  return CONFIDENCE_SCORES[level];
+}
+
+/**
+ * Convert a numeric score to the nearest confidence level.
+ * Uses closest-match: finds the level whose score is nearest.
+ *
+ * @param score - Numeric score (0.0 - 1.0)
+ * @returns The nearest confidence level
+ */
+export function scoreToConfidence(score: number): ConfidenceLevel {
+  const clamped = Math.max(0, Math.min(1, score));
+  let closest: ConfidenceLevel = 'uncertain';
+  let minDiff = Infinity;
+  for (const level of CONFIDENCE_VALUES) {
+    const diff = Math.abs(CONFIDENCE_SCORES[level] - clamped);
+    if (diff < minDiff) {
+      minDiff = diff;
+      closest = level;
+    }
+  }
+  return closest;
+}
+
+/**
+ * Resolve a source type to its corresponding tag string.
+ *
+ * @param source - The source type
+ * @returns Tag string, e.g. 'source:user-explicit'
+ */
+export function resolveSourceTag(source: SourceType): string {
+  return `${SOURCE_TAG_PREFIX}${source}`;
+}
+
+/**
+ * Parse the source type from a tag array.
+ * Looks for tags matching 'source:<type>'.
+ *
+ * @param tags - Array of tags to search
+ * @returns The source type found, or null if none present
+ */
+export function parseSourceTag(tags: readonly string[]): SourceType | null {
+  for (const tag of tags) {
+    if (tag.startsWith(SOURCE_TAG_PREFIX)) {
+      const source = tag.slice(SOURCE_TAG_PREFIX.length) as SourceType;
+      if (SOURCE_VALUES.includes(source)) {
+        return source;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Check if a string is a valid SourceType value.
+ *
+ * @param value - The string to check
+ * @returns true if valid source type
+ */
+export function isValidSource(value: string): value is SourceType {
+  return SOURCE_VALUES.includes(value as SourceType);
+}
+
+/**
+ * Get the default confidence level for a given source type.
+ *
+ * @param source - The source type
+ * @returns The default confidence level
+ */
+export function defaultConfidenceForSource(source: SourceType): ConfidenceLevel {
+  return DEFAULT_CONFIDENCE[source];
+}

--- a/src/lib/domain/interfaces/types/index.ts
+++ b/src/lib/domain/interfaces/types/index.ts
@@ -28,3 +28,20 @@ export {
   isValidLifecycle,
   computeExpiresAt,
 } from './IMemoryLifecycle';
+export {
+  ConfidenceLevel,
+  CONFIDENCE_VALUES,
+  CONFIDENCE_SCORES,
+  SourceType,
+  SOURCE_VALUES,
+  DEFAULT_CONFIDENCE,
+  resolveConfidenceTag,
+  parseConfidenceTag,
+  isValidConfidence,
+  confidenceToScore,
+  scoreToConfidence,
+  resolveSourceTag,
+  parseSourceTag,
+  isValidSource,
+  defaultConfidenceForSource,
+} from './IMemoryQuality';

--- a/tests/unit/src/lib/domain/interfaces/types/IMemoryQuality.test.ts
+++ b/tests/unit/src/lib/domain/interfaces/types/IMemoryQuality.test.ts
@@ -1,0 +1,458 @@
+/**
+ * Tests for IMemoryQuality
+ *
+ * Tests confidence levels, source types, tag resolution, parsing,
+ * score conversion, and default confidence mapping.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  CONFIDENCE_VALUES,
+  CONFIDENCE_SCORES,
+  SOURCE_VALUES,
+  DEFAULT_CONFIDENCE,
+  resolveConfidenceTag,
+  parseConfidenceTag,
+  isValidConfidence,
+  confidenceToScore,
+  scoreToConfidence,
+  resolveSourceTag,
+  parseSourceTag,
+  isValidSource,
+  defaultConfidenceForSource,
+} from '../../../../../../../src/lib/domain/interfaces/types/IMemoryQuality';
+
+describe('IMemoryQuality', () => {
+  describe('CONFIDENCE_VALUES', () => {
+    it('should contain all five confidence levels in order', () => {
+      assert.deepStrictEqual([...CONFIDENCE_VALUES], [
+        'verified',
+        'high',
+        'medium',
+        'low',
+        'uncertain',
+      ]);
+    });
+  });
+
+  describe('CONFIDENCE_SCORES', () => {
+    it('should map verified to 1.0', () => {
+      assert.strictEqual(CONFIDENCE_SCORES.verified, 1.0);
+    });
+
+    it('should map high to 0.8', () => {
+      assert.strictEqual(CONFIDENCE_SCORES.high, 0.8);
+    });
+
+    it('should map medium to 0.5', () => {
+      assert.strictEqual(CONFIDENCE_SCORES.medium, 0.5);
+    });
+
+    it('should map low to 0.3', () => {
+      assert.strictEqual(CONFIDENCE_SCORES.low, 0.3);
+    });
+
+    it('should map uncertain to 0.1', () => {
+      assert.strictEqual(CONFIDENCE_SCORES.uncertain, 0.1);
+    });
+
+    it('should have scores in descending order matching CONFIDENCE_VALUES', () => {
+      let previous = Infinity;
+      for (const level of CONFIDENCE_VALUES) {
+        const score = CONFIDENCE_SCORES[level];
+        assert.ok(score < previous, `${level} (${score}) should be less than previous (${previous})`);
+        previous = score;
+      }
+    });
+  });
+
+  describe('SOURCE_VALUES', () => {
+    it('should contain all six source types', () => {
+      assert.deepStrictEqual([...SOURCE_VALUES], [
+        'user-explicit',
+        'session-capture',
+        'prompt-capture',
+        'code-analysis',
+        'auto-inferred',
+        'external-sync',
+      ]);
+    });
+  });
+
+  describe('DEFAULT_CONFIDENCE', () => {
+    it('should map user-explicit to high', () => {
+      assert.strictEqual(DEFAULT_CONFIDENCE['user-explicit'], 'high');
+    });
+
+    it('should map session-capture to medium', () => {
+      assert.strictEqual(DEFAULT_CONFIDENCE['session-capture'], 'medium');
+    });
+
+    it('should map prompt-capture to low', () => {
+      assert.strictEqual(DEFAULT_CONFIDENCE['prompt-capture'], 'low');
+    });
+
+    it('should map code-analysis to medium', () => {
+      assert.strictEqual(DEFAULT_CONFIDENCE['code-analysis'], 'medium');
+    });
+
+    it('should map auto-inferred to low', () => {
+      assert.strictEqual(DEFAULT_CONFIDENCE['auto-inferred'], 'low');
+    });
+
+    it('should map external-sync to medium', () => {
+      assert.strictEqual(DEFAULT_CONFIDENCE['external-sync'], 'medium');
+    });
+
+    it('should have a mapping for every source type', () => {
+      for (const source of SOURCE_VALUES) {
+        assert.ok(
+          DEFAULT_CONFIDENCE[source] !== undefined,
+          `Missing default confidence for source: ${source}`
+        );
+        assert.ok(
+          CONFIDENCE_VALUES.includes(DEFAULT_CONFIDENCE[source]),
+          `Invalid confidence level for source ${source}: ${DEFAULT_CONFIDENCE[source]}`
+        );
+      }
+    });
+  });
+
+  describe('resolveConfidenceTag()', () => {
+    it('should return confidence:verified for verified', () => {
+      assert.strictEqual(resolveConfidenceTag('verified'), 'confidence:verified');
+    });
+
+    it('should return confidence:high for high', () => {
+      assert.strictEqual(resolveConfidenceTag('high'), 'confidence:high');
+    });
+
+    it('should return confidence:medium for medium', () => {
+      assert.strictEqual(resolveConfidenceTag('medium'), 'confidence:medium');
+    });
+
+    it('should return confidence:low for low', () => {
+      assert.strictEqual(resolveConfidenceTag('low'), 'confidence:low');
+    });
+
+    it('should return confidence:uncertain for uncertain', () => {
+      assert.strictEqual(resolveConfidenceTag('uncertain'), 'confidence:uncertain');
+    });
+  });
+
+  describe('parseConfidenceTag()', () => {
+    it('should extract verified from tags', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['type:fact', 'confidence:verified', 'lifecycle:permanent']),
+        'verified'
+      );
+    });
+
+    it('should extract high from tags', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['confidence:high']),
+        'high'
+      );
+    });
+
+    it('should extract medium from tags', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['source:session-capture', 'confidence:medium']),
+        'medium'
+      );
+    });
+
+    it('should extract low from tags', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['confidence:low', 'type:prompt']),
+        'low'
+      );
+    });
+
+    it('should extract uncertain from tags', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['confidence:uncertain']),
+        'uncertain'
+      );
+    });
+
+    it('should return null when no confidence tag present', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['type:fact', 'lifecycle:session']),
+        null
+      );
+    });
+
+    it('should return null for empty tags array', () => {
+      assert.strictEqual(parseConfidenceTag([]), null);
+    });
+
+    it('should ignore invalid confidence values in tags', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['confidence:invalid', 'confidence:unknown']),
+        null
+      );
+    });
+
+    it('should return first valid confidence when multiple present', () => {
+      assert.strictEqual(
+        parseConfidenceTag(['confidence:low', 'confidence:high']),
+        'low'
+      );
+    });
+  });
+
+  describe('isValidConfidence()', () => {
+    it('should return true for verified', () => {
+      assert.strictEqual(isValidConfidence('verified'), true);
+    });
+
+    it('should return true for high', () => {
+      assert.strictEqual(isValidConfidence('high'), true);
+    });
+
+    it('should return true for medium', () => {
+      assert.strictEqual(isValidConfidence('medium'), true);
+    });
+
+    it('should return true for low', () => {
+      assert.strictEqual(isValidConfidence('low'), true);
+    });
+
+    it('should return true for uncertain', () => {
+      assert.strictEqual(isValidConfidence('uncertain'), true);
+    });
+
+    it('should return false for invalid values', () => {
+      assert.strictEqual(isValidConfidence('invalid'), false);
+      assert.strictEqual(isValidConfidence(''), false);
+      assert.strictEqual(isValidConfidence('HIGH'), false);
+      assert.strictEqual(isValidConfidence('Verified'), false);
+    });
+  });
+
+  describe('confidenceToScore()', () => {
+    it('should return 1.0 for verified', () => {
+      assert.strictEqual(confidenceToScore('verified'), 1.0);
+    });
+
+    it('should return 0.8 for high', () => {
+      assert.strictEqual(confidenceToScore('high'), 0.8);
+    });
+
+    it('should return 0.5 for medium', () => {
+      assert.strictEqual(confidenceToScore('medium'), 0.5);
+    });
+
+    it('should return 0.3 for low', () => {
+      assert.strictEqual(confidenceToScore('low'), 0.3);
+    });
+
+    it('should return 0.1 for uncertain', () => {
+      assert.strictEqual(confidenceToScore('uncertain'), 0.1);
+    });
+  });
+
+  describe('scoreToConfidence()', () => {
+    it('should return verified for 1.0', () => {
+      assert.strictEqual(scoreToConfidence(1.0), 'verified');
+    });
+
+    it('should return high for 0.8', () => {
+      assert.strictEqual(scoreToConfidence(0.8), 'high');
+    });
+
+    it('should return medium for 0.5', () => {
+      assert.strictEqual(scoreToConfidence(0.5), 'medium');
+    });
+
+    it('should return low for 0.3', () => {
+      assert.strictEqual(scoreToConfidence(0.3), 'low');
+    });
+
+    it('should return uncertain for 0.1', () => {
+      assert.strictEqual(scoreToConfidence(0.1), 'uncertain');
+    });
+
+    it('should return nearest level for in-between scores', () => {
+      // 0.9 is closest to verified (1.0) vs high (0.8)
+      assert.strictEqual(scoreToConfidence(0.9), 'verified');
+      // 0.65 is closest to high (0.8) vs medium (0.5)
+      assert.strictEqual(scoreToConfidence(0.65), 'high');
+      // 0.4 is closest to medium (0.5) vs low (0.3)
+      assert.strictEqual(scoreToConfidence(0.4), 'medium');
+      // 0.2 is closest to low (0.3) vs uncertain (0.1)
+      assert.strictEqual(scoreToConfidence(0.2), 'low');
+      // 0.05 is closest to uncertain (0.1)
+      assert.strictEqual(scoreToConfidence(0.05), 'uncertain');
+    });
+
+    it('should clamp scores above 1.0 to verified', () => {
+      assert.strictEqual(scoreToConfidence(1.5), 'verified');
+      assert.strictEqual(scoreToConfidence(100), 'verified');
+    });
+
+    it('should clamp scores below 0.0 to uncertain', () => {
+      assert.strictEqual(scoreToConfidence(-0.5), 'uncertain');
+      assert.strictEqual(scoreToConfidence(-100), 'uncertain');
+    });
+
+    it('should return uncertain for 0.0', () => {
+      assert.strictEqual(scoreToConfidence(0.0), 'uncertain');
+    });
+  });
+
+  describe('resolveSourceTag()', () => {
+    it('should return source:user-explicit for user-explicit', () => {
+      assert.strictEqual(resolveSourceTag('user-explicit'), 'source:user-explicit');
+    });
+
+    it('should return source:session-capture for session-capture', () => {
+      assert.strictEqual(resolveSourceTag('session-capture'), 'source:session-capture');
+    });
+
+    it('should return source:prompt-capture for prompt-capture', () => {
+      assert.strictEqual(resolveSourceTag('prompt-capture'), 'source:prompt-capture');
+    });
+
+    it('should return source:code-analysis for code-analysis', () => {
+      assert.strictEqual(resolveSourceTag('code-analysis'), 'source:code-analysis');
+    });
+
+    it('should return source:auto-inferred for auto-inferred', () => {
+      assert.strictEqual(resolveSourceTag('auto-inferred'), 'source:auto-inferred');
+    });
+
+    it('should return source:external-sync for external-sync', () => {
+      assert.strictEqual(resolveSourceTag('external-sync'), 'source:external-sync');
+    });
+  });
+
+  describe('parseSourceTag()', () => {
+    it('should extract user-explicit from tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['type:fact', 'source:user-explicit', 'confidence:high']),
+        'user-explicit'
+      );
+    });
+
+    it('should extract session-capture from tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:session-capture']),
+        'session-capture'
+      );
+    });
+
+    it('should extract prompt-capture from tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:prompt-capture', 'lifecycle:ephemeral']),
+        'prompt-capture'
+      );
+    });
+
+    it('should extract code-analysis from tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:code-analysis']),
+        'code-analysis'
+      );
+    });
+
+    it('should extract auto-inferred from tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:auto-inferred']),
+        'auto-inferred'
+      );
+    });
+
+    it('should extract external-sync from tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:external-sync']),
+        'external-sync'
+      );
+    });
+
+    it('should return null when no source tag present', () => {
+      assert.strictEqual(
+        parseSourceTag(['type:fact', 'confidence:high']),
+        null
+      );
+    });
+
+    it('should return null for empty tags array', () => {
+      assert.strictEqual(parseSourceTag([]), null);
+    });
+
+    it('should ignore invalid source values in tags', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:invalid', 'source:unknown']),
+        null
+      );
+    });
+
+    it('should return first valid source when multiple present', () => {
+      assert.strictEqual(
+        parseSourceTag(['source:session-capture', 'source:user-explicit']),
+        'session-capture'
+      );
+    });
+  });
+
+  describe('isValidSource()', () => {
+    it('should return true for user-explicit', () => {
+      assert.strictEqual(isValidSource('user-explicit'), true);
+    });
+
+    it('should return true for session-capture', () => {
+      assert.strictEqual(isValidSource('session-capture'), true);
+    });
+
+    it('should return true for prompt-capture', () => {
+      assert.strictEqual(isValidSource('prompt-capture'), true);
+    });
+
+    it('should return true for code-analysis', () => {
+      assert.strictEqual(isValidSource('code-analysis'), true);
+    });
+
+    it('should return true for auto-inferred', () => {
+      assert.strictEqual(isValidSource('auto-inferred'), true);
+    });
+
+    it('should return true for external-sync', () => {
+      assert.strictEqual(isValidSource('external-sync'), true);
+    });
+
+    it('should return false for invalid values', () => {
+      assert.strictEqual(isValidSource('invalid'), false);
+      assert.strictEqual(isValidSource(''), false);
+      assert.strictEqual(isValidSource('USER-EXPLICIT'), false);
+      assert.strictEqual(isValidSource('user_explicit'), false);
+    });
+  });
+
+  describe('defaultConfidenceForSource()', () => {
+    it('should return high for user-explicit', () => {
+      assert.strictEqual(defaultConfidenceForSource('user-explicit'), 'high');
+    });
+
+    it('should return medium for session-capture', () => {
+      assert.strictEqual(defaultConfidenceForSource('session-capture'), 'medium');
+    });
+
+    it('should return low for prompt-capture', () => {
+      assert.strictEqual(defaultConfidenceForSource('prompt-capture'), 'low');
+    });
+
+    it('should return medium for code-analysis', () => {
+      assert.strictEqual(defaultConfidenceForSource('code-analysis'), 'medium');
+    });
+
+    it('should return low for auto-inferred', () => {
+      assert.strictEqual(defaultConfidenceForSource('auto-inferred'), 'low');
+    });
+
+    it('should return medium for external-sync', () => {
+      assert.strictEqual(defaultConfidenceForSource('external-sync'), 'medium');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ConfidenceLevel` type (verified, high, medium, low, uncertain) with numeric score mapping
- Adds `SourceType` type (user-explicit, session-capture, prompt-capture, code-analysis, auto-inferred, external-sync)
- Adds `DEFAULT_CONFIDENCE` mapping from source type to confidence level
- Adds 9 helper functions for tag resolution, parsing, validation, and score conversion
- Adds `IQualityFilter` and `IConflictGroup` DAL types
- Adds `IMemoryRepositoryQuality` interface with `findByMinConfidence()` and `findConflicts()`
- Adds `IReadOnlyMemoryRepositoryWithQuality` composite interface
- Extends `IMemorySaveOptions` with optional `confidence` and `sourceType` fields
- Extends `IQueryOptions` with optional `quality` filter
- 78 unit tests covering all helper functions and edge cases

## Test plan

- [x] All 78 new unit tests pass
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] Linting passes (`npm run lint`)
- [x] Existing tests unaffected (pre-existing failure in SessionContextFormatter is on main)

Closes #125
Part of #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Memory quality tracking with confidence levels (verified, high, medium, low, uncertain)
  * Memory source tracking to identify where memories originate
  * Filter memories by minimum confidence level
  * Conflict detection for memories with different provenance
  * Extended save options to include confidence and source metadata

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->