### PR TITLE
feat(memory): Add memory compaction service with archive and summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Memory Compaction Service ([#153](https://github.com/TonyCasey/lisa/issues/153))
+
+Added memory compaction — groups old facts by topic category, creates template-based summaries, and archives (expires) the originals.
+
+- `ICompactionService`, `ICompactionResult`, `ICompactionSummary` domain types
+- `CompactionService` infrastructure implementation with DI registration
+- Fact grouping by name prefix (e.g., `DECISION:`) or `type:` tag, with `general` fallback
+- Template-based summaries: `[Compacted] Topic: N items from <earliest> to <latest>: <snippets>`
+- Skill-level `compact()` method with Neo4j Cypher queries including tag retrieval
+- `lisa memory compact --before <date>` CLI command with `--dry-run` and `--min-group` options
+- Full test coverage: 15 CompactionService tests, 8 MemoryCliService compact tests
+
+Part of Epic [#149](https://github.com/TonyCasey/lisa/issues/149)
+
 #### Structured ProjectContext with Session Integration ([#152](https://github.com/TonyCasey/lisa/issues/152))
 
 Added structured project context — a curated snapshot of tech stack, key decisions, constraints, and conventions that loads automatically at session start.

--- a/src/lib/commands/knowledge.ts
+++ b/src/lib/commands/knowledge.ts
@@ -120,6 +120,25 @@ export function registerKnowledgeCommands(program: Command): void {
       await spawnAndWait(scriptPath, args, getSkillCacheEnv('memory'));
     });
 
+  memoryCmd
+    .command('compact')
+    .description('Compact old memories into summaries (e.g. lisa memory compact --before 30d --dry-run)')
+    .requiredOption('--before <date>', 'Compact facts older than date (relative: 30d, 3m, 1y; or ISO date)')
+    .option('--dry-run', 'Preview without making changes')
+    .option('--min-group <n>', 'Minimum facts per group to compact', '3')
+    .option('-g, --group <id>', 'Group ID')
+    .option('--cache', 'Use cache fallback')
+    .action(async (opts) => {
+      const args = ['compact'];
+      args.push('--before', opts.before);
+      if (opts.dryRun) args.push('--dry-run');
+      if (opts.minGroup) args.push('--min-group', String(parseInt(opts.minGroup, 10)));
+      if (opts.group) args.push('--group', opts.group);
+      if (opts.cache) args.push('--cache');
+      const scriptPath = path.join(__dirname, '..', 'skills', 'memory', 'memory.js');
+      await spawnAndWait(scriptPath, args, getSkillCacheEnv('memory'));
+    });
+
   // Subcommand: lisa tasks
   const tasksCmd = program
     .command('tasks')

--- a/src/lib/domain/interfaces/ICompactionService.ts
+++ b/src/lib/domain/interfaces/ICompactionService.ts
@@ -1,0 +1,58 @@
+/**
+ * Memory Compaction Service Interface
+ *
+ * Defines the contract for compacting old memory facts
+ * into summary facts with optional archival relationships.
+ * Template-based summaries; LLM-assisted summarization deferred to Phase 6.
+ */
+
+/**
+ * Summary of a compacted group of facts.
+ */
+export interface ICompactionSummary {
+  readonly topic: string;
+  readonly factCount: number;
+  readonly summaryText: string;
+  readonly archivedUuids: readonly string[];
+}
+
+/**
+ * Result of a compaction operation.
+ */
+export interface ICompactionResult {
+  readonly groupsProcessed: number;
+  readonly factsArchived: number;
+  readonly summariesCreated: number;
+  readonly summaries: readonly ICompactionSummary[];
+}
+
+/**
+ * Options for compaction operations.
+ */
+export interface ICompactionOptions {
+  readonly olderThan: Date;
+  readonly dryRun?: boolean;
+  readonly minGroupSize?: number;
+}
+
+/**
+ * Memory compaction service interface.
+ *
+ * Groups old facts by topic, creates summary facts, and archives originals.
+ */
+export interface ICompactionService {
+  /**
+   * Compact old facts into summaries.
+   * @param groupId - Group ID to compact within
+   * @param options - Compaction options (date cutoff, dry run, min group size)
+   */
+  compact(groupId: string, options: ICompactionOptions): Promise<ICompactionResult>;
+
+  /**
+   * Preview compaction without making changes.
+   * Equivalent to compact() with dryRun: true.
+   * @param groupId - Group ID to preview
+   * @param options - Preview options (date cutoff, min group size)
+   */
+  preview(groupId: string, options: Omit<ICompactionOptions, 'dryRun'>): Promise<ICompactionResult>;
+}

--- a/src/lib/domain/interfaces/index.ts
+++ b/src/lib/domain/interfaces/index.ts
@@ -59,3 +59,11 @@ export * from './types';
 
 // Re-export project context types at top level for convenience
 export type { IProjectContext, IProjectContextUpdates, IProjectContextService } from './types/IProjectContext';
+
+// Compaction service
+export type {
+  ICompactionSummary,
+  ICompactionResult,
+  ICompactionOptions,
+  ICompactionService,
+} from './ICompactionService';

--- a/src/lib/infrastructure/di/bootstrap.ts
+++ b/src/lib/infrastructure/di/bootstrap.ts
@@ -42,6 +42,7 @@ import {
   SessionCaptureService,
   RecursionService,
   ProjectContextService,
+  CompactionService,
 } from '../services';
 import { createRepositoryRouter, closeConnections, Neo4jMemoryRelationshipRepository } from '../dal';
 import type { IMemoryRelationshipRepository } from '../../domain/interfaces/dal/IMemoryRelationshipRepository';
@@ -209,6 +210,16 @@ export async function bootstrapContainer(config: IServiceConfig = {}): Promise<I
       const memory = await container.resolve<MemoryService>(TOKENS.MemoryService);
       const tasks = await container.resolve<TaskService>(TOKENS.TaskService);
       return new RecursionService(memory, tasks);
+    },
+    'transient'
+  );
+
+  // Compaction Service (transient - stateless)
+  container.register(
+    TOKENS.CompactionService,
+    async () => {
+      const mem = await container.resolve<IMemoryService>(TOKENS.MemoryService);
+      return new CompactionService(mem);
     },
     'transient'
   );

--- a/src/lib/infrastructure/di/tokens.ts
+++ b/src/lib/infrastructure/di/tokens.ts
@@ -29,6 +29,7 @@ export const INFRA_TOKENS = {
   GitHubSyncService: Symbol.for('Lisa.GitHubSyncService'),
   MemoryRelationshipRepository: Symbol.for('Lisa.MemoryRelationshipRepository'),
   ProjectContextService: Symbol.for('Lisa.ProjectContextService'),
+  CompactionService: Symbol.for('Lisa.CompactionService'),
 } as const;
 
 /**

--- a/src/lib/infrastructure/services/CompactionService.ts
+++ b/src/lib/infrastructure/services/CompactionService.ts
@@ -1,0 +1,173 @@
+/**
+ * CompactionService
+ *
+ * Groups old facts by topic, creates template-based summary facts,
+ * and archives (expires) the originals.
+ * LLM-assisted summarization is deferred to Phase 6.
+ */
+
+import type {
+  ICompactionService,
+  ICompactionOptions,
+  ICompactionResult,
+  ICompactionSummary,
+  IMemoryService,
+  IMemoryItem,
+} from '../../domain';
+
+const DEFAULT_MIN_GROUP_SIZE = 3;
+const MAX_FACTS_TO_LOAD = 500;
+const MAX_SUMMARY_SNIPPETS = 3;
+const SNIPPET_MAX_LENGTH = 50;
+
+/**
+ * A group of facts sharing a common topic/category.
+ */
+interface IFactGroup {
+  readonly topic: string;
+  readonly items: readonly IMemoryItem[];
+}
+
+/**
+ * Extract a category from a memory item's name prefix or tags.
+ */
+function extractCategory(item: IMemoryItem): string {
+  // Check name for PREFIX: pattern (e.g., "DECISION: ...", "MILESTONE: ...")
+  if (item.name) {
+    const prefixMatch = item.name.match(/^([A-Z_]+):\s/);
+    if (prefixMatch) return prefixMatch[1].toLowerCase();
+  }
+
+  // Check tags for type:* tag (e.g., "type:decision", "type:milestone")
+  if (item.tags) {
+    for (const tag of item.tags) {
+      if (tag.startsWith('type:') && tag !== 'type:compaction-summary') {
+        return tag.slice(5);
+      }
+    }
+  }
+
+  return 'general';
+}
+
+export class CompactionService implements ICompactionService {
+  constructor(
+    private readonly memoryService: IMemoryService
+  ) {}
+
+  async compact(groupId: string, options: ICompactionOptions): Promise<ICompactionResult> {
+    return this.runCompaction(groupId, options);
+  }
+
+  async preview(groupId: string, options: Omit<ICompactionOptions, 'dryRun'>): Promise<ICompactionResult> {
+    return this.runCompaction(groupId, { ...options, dryRun: true });
+  }
+
+  private async runCompaction(groupId: string, options: ICompactionOptions): Promise<ICompactionResult> {
+    const { olderThan, dryRun = false, minGroupSize = DEFAULT_MIN_GROUP_SIZE } = options;
+
+    // Load old, non-expired facts
+    const facts = await this.memoryService.loadFactsDateOrdered(
+      [groupId], MAX_FACTS_TO_LOAD, { until: olderThan }
+    );
+
+    // Group by category
+    const groups = this.groupByCategory(facts);
+
+    // Filter groups smaller than threshold
+    const qualifying = groups.filter(g => g.items.length >= minGroupSize);
+
+    let factsArchived = 0;
+    let summariesCreated = 0;
+    const summaries: ICompactionSummary[] = [];
+
+    for (const group of qualifying) {
+      const summary = this.generateSummary(group);
+      summaries.push(summary);
+
+      if (!dryRun) {
+        // Save summary fact with compaction tags
+        const summaryTags = ['type:compaction-summary', `compacted:${group.topic}`];
+        await this.memoryService.addFact(groupId, summary.summaryText, summaryTags);
+
+        // Expire original facts
+        for (const uuid of summary.archivedUuids) {
+          await this.memoryService.expireFact(groupId, uuid);
+        }
+      }
+
+      factsArchived += summary.archivedUuids.length;
+      summariesCreated++;
+    }
+
+    return {
+      groupsProcessed: qualifying.length,
+      factsArchived,
+      summariesCreated,
+      summaries,
+    };
+  }
+
+  /**
+   * Group facts by their extracted category.
+   */
+  private groupByCategory(facts: readonly IMemoryItem[]): IFactGroup[] {
+    const map = new Map<string, IMemoryItem[]>();
+
+    for (const fact of facts) {
+      const category = extractCategory(fact);
+      const existing = map.get(category);
+      if (existing) {
+        existing.push(fact);
+      } else {
+        map.set(category, [fact]);
+      }
+    }
+
+    return Array.from(map.entries()).map(([topic, items]) => ({ topic, items }));
+  }
+
+  /**
+   * Generate a template-based summary for a group of facts.
+   */
+  private generateSummary(group: IFactGroup): ICompactionSummary {
+    const { topic, items } = group;
+
+    // Sort by date ascending for range display
+    const sorted = [...items].sort((a, b) => {
+      const ad = a.created_at ? new Date(a.created_at).getTime() : 0;
+      const bd = b.created_at ? new Date(b.created_at).getTime() : 0;
+      return ad - bd;
+    });
+
+    const firstDate = sorted[0]?.created_at;
+    const lastDate = sorted[sorted.length - 1]?.created_at;
+    const earliest = firstDate
+      ? new Date(firstDate).toISOString().split('T')[0]
+      : 'unknown';
+    const latest = lastDate
+      ? new Date(lastDate).toISOString().split('T')[0]
+      : 'unknown';
+
+    // Build snippet list from first few facts
+    const snippets = sorted.slice(0, MAX_SUMMARY_SNIPPETS).map(f => {
+      const text = f.fact || f.name || '';
+      return text.length > SNIPPET_MAX_LENGTH ? text.slice(0, SNIPPET_MAX_LENGTH - 3) + '...' : text;
+    });
+    const snippetText = snippets.join('; ');
+
+    const topicLabel = topic.charAt(0).toUpperCase() + topic.slice(1);
+    const summaryText = `[Compacted] ${topicLabel}: ${items.length} items from ${earliest} to ${latest}: ${snippetText}`;
+
+    const archivedUuids = items
+      .map(f => f.uuid)
+      .filter((u): u is string => u !== undefined);
+
+    return {
+      topic,
+      factCount: items.length,
+      summaryText,
+      archivedUuids,
+    };
+  }
+}

--- a/src/lib/infrastructure/services/index.ts
+++ b/src/lib/infrastructure/services/index.ts
@@ -9,3 +9,4 @@ export { SessionCaptureService } from './SessionCaptureService';
 export { RecursionService } from './RecursionService';
 export { LabelInferenceService, createLabelInferenceService } from './LabelInferenceService';
 export { ProjectContextService } from './ProjectContextService';
+export { CompactionService } from './CompactionService';

--- a/src/lib/skills/memory/memory.ts
+++ b/src/lib/skills/memory/memory.ts
@@ -9,6 +9,7 @@
  *   node memory.js cleanup [--group <id>] [--dry-run] [--cache]
  *   node memory.js link <sourceUuid> <targetUuid> [--type <relationType>] [--note <text>] [--group <id>] [--cache]
  *   node memory.js links <uuid> [--type <relationType>] [--group <id>] [--cache]
+ *   node memory.js compact --before <date> [--dry-run] [--min-group N] [--group <id>] [--cache]
  */
 
 export {};
@@ -44,6 +45,8 @@ async function main(): Promise<void> {
   const ttl = popFlag(args, '--ttl', null);
   const uuid = popFlag(args, '--uuid', null);
   const note = popFlag(args, '--note', null);
+  const before = popFlag(args, '--before', null);
+  const minGroup = Number(popFlag(args, '--min-group', '3')) || 3;
   const dryRun = hasFlag(args, '--dry-run');
   const useCache = hasFlag(args, '--cache');
   const payload = args.join(' ').trim();
@@ -63,7 +66,7 @@ async function main(): Promise<void> {
   try {
     const result = await cliService.run({
       command, payload, explicitGroup, query, limit, explicitTag,
-      entityType, source, since, until, lifecycle, ttl, dryRun, uuid, note,
+      entityType, source, since, until, lifecycle, ttl, dryRun, uuid, note, before, minGroup,
     });
     console.log(JSON.stringify(result, null, 2));
   } catch (err: unknown) {

--- a/src/lib/skills/shared/services/MemoryCliService.ts
+++ b/src/lib/skills/shared/services/MemoryCliService.ts
@@ -13,12 +13,13 @@ import type {
   IMemoryLoadOptions,
   IMemoryLinkResult,
   IMemoryLinksResult,
+  IMemoryCompactResult,
 } from './interfaces';
 import { isValidRelationType } from '../../../domain/interfaces/types/IMemoryRelationship';
 import { parseDate } from '../../../utils/dateParser';
 
 /** CLI result union for all memory commands. */
-export type MemoryCliResult = IMemoryLoadResult | IMemoryAddResult | IMemoryExpireResult | IMemoryCleanupResult | IMemoryLinkResult | IMemoryLinksResult;
+export type MemoryCliResult = IMemoryLoadResult | IMemoryAddResult | IMemoryExpireResult | IMemoryCleanupResult | IMemoryLinkResult | IMemoryLinksResult | IMemoryCompactResult;
 
 /**
  * Parsed memory CLI arguments.
@@ -39,6 +40,8 @@ export interface IMemoryCliArgs {
   dryRun: boolean;
   uuid: string | null;
   note: string | null;
+  before: string | null;
+  minGroup: number;
 }
 
 /**
@@ -117,11 +120,11 @@ export function createMemoryCliService(deps: IMemoryCliDependencies): IMemoryCli
       const {
         command, payload, explicitGroup, query, limit,
         explicitTag, entityType, source, since, until,
-        lifecycle, ttl, dryRun, uuid, note,
+        lifecycle, ttl, dryRun, uuid, note, before, minGroup,
       } = args;
 
-      if (!['add', 'load', 'expire', 'cleanup', 'link', 'links'].includes(command)) {
-        throw new Error('command must be add|load|expire|cleanup|link|links');
+      if (!['add', 'load', 'expire', 'cleanup', 'link', 'links', 'compact'].includes(command)) {
+        throw new Error('command must be add|load|expire|cleanup|link|links|compact');
       }
 
       // Use explicit --group if provided, otherwise use canonical folder-based group ID
@@ -183,6 +186,19 @@ export function createMemoryCliService(deps: IMemoryCliDependencies): IMemoryCli
           throw new Error(`Invalid relation type: "${relationType}". Valid types: supersedes, supports, contradicts, implements, relates_to, refines`);
         }
         result = await memoryService.getRelatedFacts(groupId, targetUuid, relationType);
+      } else if (command === 'compact') {
+        if (!before) {
+          throw new Error('compact requires --before <date>: lisa memory compact --before 30d');
+        }
+        const parsedBefore = parseDate(before);
+        if (!parsedBefore) {
+          throw new Error(`Invalid --before date: "${before}". Use formats like: 30d, 3m, 1y, or ISO date (2026-01-01)`);
+        }
+        result = await memoryService.compact(groupId, {
+          olderThan: parsedBefore,
+          dryRun,
+          minGroupSize: minGroup,
+        });
       } else {
         // add
         if (!payload) throw new Error('add requires text payload');

--- a/src/lib/skills/shared/services/MemoryService.ts
+++ b/src/lib/skills/shared/services/MemoryService.ts
@@ -17,6 +17,9 @@ import type {
   IMemoryLinkResult,
   IMemoryLinksResult,
   IMemoryRelationshipItem,
+  IMemoryCompactResult,
+  IMemoryCompactOptions,
+  ICompactGroupSummary,
 } from './interfaces';
 import { LIFECYCLE_DEFAULTS, resolveLifecycleTag } from '../../../domain/interfaces/types/IMemoryLifecycle';
 import type { MemoryLifecycle } from '../../../domain/interfaces/types/IMemoryLifecycle';
@@ -471,5 +474,169 @@ export function createMemoryService(deps: IMemoryServiceDependencies): IMemorySe
         await neo4jClient.disconnect();
       }
     },
+
+    async compact(
+      groupId: string,
+      options: IMemoryCompactOptions
+    ): Promise<IMemoryCompactResult> {
+      const { olderThan, dryRun, minGroupSize } = options;
+
+      await neo4jClient.connect();
+      try {
+        // Step 1: Load old non-expired facts with tags
+        const loadCypher = `
+          MATCH (s:Entity)-[r]->(t:Entity)
+          WHERE r.group_id = $groupId
+            AND r.expired_at IS NULL
+            AND r.created_at <= datetime($before)
+          RETURN r.uuid AS uuid, r.name AS name, r.fact AS fact,
+                 r.group_id AS group_id, r.created_at AS created_at,
+                 coalesce(r.tags, []) AS tags
+          ORDER BY r.created_at ASC
+        `;
+        const facts = await neo4jClient.query<{
+          uuid: string;
+          name: string;
+          fact: string;
+          group_id: string;
+          created_at: string;
+          tags: string[];
+        }>(loadCypher, {
+          groupId,
+          before: olderThan.toISOString(),
+        });
+
+        // Step 2: Group by category
+        const categoryMap = new Map<string, typeof facts>();
+        for (const f of facts) {
+          const category = extractFactCategory(f.name, f.tags);
+          const existing = categoryMap.get(category);
+          if (existing) {
+            existing.push(f);
+          } else {
+            categoryMap.set(category, [f]);
+          }
+        }
+
+        // Step 3: Filter groups smaller than threshold
+        const qualifying = Array.from(categoryMap.entries())
+          .filter(([, items]) => items.length >= minGroupSize);
+
+        let factsArchived = 0;
+        let summariesCreated = 0;
+        const summaries: ICompactGroupSummary[] = [];
+
+        for (const [topic, items] of qualifying) {
+          const summary = generateCompactSummary(topic, items);
+          summaries.push(summary);
+
+          if (!dryRun) {
+            // Save summary fact via MCP
+            const summaryTag = `type:compaction-summary`;
+            const mcpTag = `compacted:${topic}`;
+
+            if (zepClient) {
+              await zepClient.addMemory(groupId, summary.summaryText, {
+                tag: summaryTag,
+                source: 'compaction',
+              });
+            } else {
+              await mcpClient.initialize();
+              await mcpClient.rpcCall('add_memory', {
+                name: `[Compacted] ${topic}: ${items.length} items`,
+                episode_body: summary.summaryText,
+                source: 'compaction',
+                group_id: groupId,
+                tags: [summaryTag, mcpTag],
+              });
+            }
+
+            // Expire original facts
+            for (const uuid of summary.archivedUuids) {
+              const expireCypher = `
+                MATCH (s:Entity)-[r]->(t:Entity)
+                WHERE r.group_id = $groupId AND r.uuid = $uuid AND r.expired_at IS NULL
+                SET r.expired_at = datetime()
+              `;
+              await neo4jClient.writeQuery(expireCypher, { groupId, uuid });
+            }
+
+            factsArchived += summary.archivedUuids.length;
+            summariesCreated++;
+          } else {
+            factsArchived += summary.archivedUuids.length;
+            summariesCreated++;
+          }
+        }
+
+        return {
+          status: 'ok',
+          action: 'compact',
+          group: groupId,
+          groupsProcessed: qualifying.length,
+          factsArchived,
+          summariesCreated,
+          summaries,
+          dryRun,
+          mode: 'neo4j',
+        };
+      } finally {
+        await neo4jClient.disconnect();
+      }
+    },
+  };
+}
+
+/**
+ * Extract a category from a fact's name prefix or tags.
+ */
+function extractFactCategory(name: string, tags: string[]): string {
+  // Check name for PREFIX: pattern (e.g., "DECISION: ...", "MILESTONE: ...")
+  if (name) {
+    const prefixMatch = name.match(/^([A-Z_]+):\s/);
+    if (prefixMatch) return prefixMatch[1].toLowerCase();
+  }
+
+  // Check tags for type:* tag
+  for (const tag of tags) {
+    if (tag.startsWith('type:') && tag !== 'type:compaction-summary') {
+      return tag.slice(5);
+    }
+  }
+
+  return 'general';
+}
+
+/**
+ * Generate a template-based summary for a group of facts.
+ */
+function generateCompactSummary(
+  topic: string,
+  items: ReadonlyArray<{ uuid: string; name: string; fact: string; created_at: string }>
+): ICompactGroupSummary {
+  const earliest = items[0]?.created_at
+    ? new Date(items[0].created_at).toISOString().split('T')[0]
+    : 'unknown';
+  const latest = items[items.length - 1]?.created_at
+    ? new Date(items[items.length - 1].created_at).toISOString().split('T')[0]
+    : 'unknown';
+
+  // Build snippet list from first 3 facts
+  const snippets = items.slice(0, 3).map(f => {
+    const text = f.fact || f.name || '';
+    return text.length > 50 ? text.slice(0, 47) + '...' : text;
+  });
+  const snippetText = snippets.join('; ');
+
+  const topicLabel = topic.charAt(0).toUpperCase() + topic.slice(1);
+  const summaryText = `[Compacted] ${topicLabel}: ${items.length} items from ${earliest} to ${latest}: ${snippetText}`;
+
+  const archivedUuids = items.map(f => f.uuid).filter(Boolean);
+
+  return {
+    topic,
+    factCount: items.length,
+    summaryText,
+    archivedUuids,
   };
 }

--- a/src/lib/skills/shared/services/interfaces/IMemoryService.ts
+++ b/src/lib/skills/shared/services/interfaces/IMemoryService.ts
@@ -122,6 +122,40 @@ export interface IMemoryLinksResult {
 }
 
 /**
+ * Summary of a compacted group of facts.
+ */
+export interface ICompactGroupSummary {
+  topic: string;
+  factCount: number;
+  summaryText: string;
+  archivedUuids: string[];
+}
+
+/**
+ * Result of a memory compact operation.
+ */
+export interface IMemoryCompactResult {
+  status: 'ok';
+  action: 'compact';
+  group: string;
+  groupsProcessed: number;
+  factsArchived: number;
+  summariesCreated: number;
+  summaries: ICompactGroupSummary[];
+  dryRun: boolean;
+  mode: 'neo4j';
+}
+
+/**
+ * Options for memory compaction.
+ */
+export interface IMemoryCompactOptions {
+  olderThan: Date;
+  dryRun: boolean;
+  minGroupSize: number;
+}
+
+/**
  * Memory service interface.
  */
 export interface IMemoryService {
@@ -210,4 +244,17 @@ export interface IMemoryService {
     uuid: string,
     relationType?: string
   ): Promise<IMemoryLinksResult>;
+
+  /**
+   * Compact old facts into summaries.
+   * Groups old non-expired facts by category, creates template-based summaries,
+   * and archives (expires) the originals.
+   *
+   * @param groupId - Group identifier
+   * @param options - Compaction options (date cutoff, dry run, min group size)
+   */
+  compact(
+    groupId: string,
+    options: IMemoryCompactOptions
+  ): Promise<IMemoryCompactResult>;
 }

--- a/tests/unit/src/lib/infrastructure/services/CompactionService.test.ts
+++ b/tests/unit/src/lib/infrastructure/services/CompactionService.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Tests for CompactionService.
+ *
+ * Tests fact grouping, summary generation, and compaction orchestration.
+ */
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { CompactionService } from '../../../../../../src/lib/infrastructure/services/CompactionService';
+import type { IMemoryItem } from '../../../../../../src/lib/domain/interfaces/types/IMemoryResult';
+
+/** Tracking arrays for mock calls. */
+let addFactCalls: Array<{ groupId: string; fact: string; tags: readonly string[] }>;
+let expireFactCalls: Array<{ groupId: string; uuid: string }>;
+let loadFactsCalls: Array<{ groupIds: readonly string[]; limit: number; options?: { until?: Date } }>;
+
+function createMockMemoryService(factsToReturn: IMemoryItem[] = []) {
+  return {
+    loadMemory: async () => ({ facts: [], nodes: [], tasks: [], timedOut: false, initReview: null }),
+    loadFactsDateOrdered: async (groupIds: readonly string[], limit: number, options?: { since?: Date; until?: Date }) => {
+      loadFactsCalls.push({ groupIds, limit, options: options ? { until: options.until } : undefined });
+      return factsToReturn;
+    },
+    searchFacts: async () => [],
+    saveMemory: async () => {},
+    addFact: async (groupId: string, fact: string, tags: readonly string[] = []) => {
+      addFactCalls.push({ groupId, fact, tags });
+    },
+    addFactWithLifecycle: async () => {},
+    expireFact: async (groupId: string, uuid: string) => {
+      expireFactCalls.push({ groupId, uuid });
+    },
+    cleanupExpired: async () => 0,
+  };
+}
+
+describe('CompactionService', () => {
+  beforeEach(() => {
+    addFactCalls = [];
+    expireFactCalls = [];
+    loadFactsCalls = [];
+  });
+
+  describe('compact()', () => {
+    it('should return empty result when no facts exist', async () => {
+      const service = new CompactionService(createMockMemoryService([]));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+      });
+
+      assert.strictEqual(result.groupsProcessed, 0);
+      assert.strictEqual(result.factsArchived, 0);
+      assert.strictEqual(result.summariesCreated, 0);
+      assert.deepStrictEqual(result.summaries, []);
+    });
+
+    it('should skip groups smaller than minGroupSize', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'a', name: 'DECISION: Use Redis', fact: 'Use Redis for caching', created_at: '2025-12-01T00:00:00.000Z' },
+        { uuid: 'b', name: 'MILESTONE: Released v1', fact: 'Released v1', created_at: '2025-12-02T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        minGroupSize: 3,
+      });
+
+      // Each category has only 1 fact, below threshold
+      assert.strictEqual(result.groupsProcessed, 0);
+      assert.strictEqual(result.factsArchived, 0);
+    });
+
+    it('should group facts by name prefix and generate summaries', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'a1', name: 'DECISION: Use Redis', fact: 'Use Redis for caching', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'a2', name: 'DECISION: Use TypeScript', fact: 'Use TypeScript', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'a3', name: 'DECISION: Use Neo4j', fact: 'Use Neo4j', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      assert.strictEqual(result.groupsProcessed, 1);
+      assert.strictEqual(result.summariesCreated, 1);
+      assert.strictEqual(result.factsArchived, 3);
+      assert.strictEqual(result.summaries[0].topic, 'decision');
+      assert.strictEqual(result.summaries[0].factCount, 3);
+      assert.ok(result.summaries[0].summaryText.includes('[Compacted] Decision:'));
+      assert.ok(result.summaries[0].summaryText.includes('3 items'));
+    });
+
+    it('should group facts by type: tag when no name prefix', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'b1', name: 'some fact', fact: 'fact one', tags: ['type:milestone'], created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'b2', name: 'another fact', fact: 'fact two', tags: ['type:milestone'], created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'b3', name: 'third fact', fact: 'fact three', tags: ['type:milestone'], created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      assert.strictEqual(result.groupsProcessed, 1);
+      assert.strictEqual(result.summaries[0].topic, 'milestone');
+    });
+
+    it('should group untagged facts under "general"', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'c1', name: 'fact one', fact: 'just a fact', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'c2', name: 'fact two', fact: 'another fact', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'c3', name: 'fact three', fact: 'yet another', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      assert.strictEqual(result.summaries[0].topic, 'general');
+    });
+
+    it('should not expire or add facts in dry run mode', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'd1', name: 'DECISION: A', fact: 'A', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'd2', name: 'DECISION: B', fact: 'B', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'd3', name: 'DECISION: C', fact: 'C', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      assert.strictEqual(addFactCalls.length, 0);
+      assert.strictEqual(expireFactCalls.length, 0);
+    });
+
+    it('should save summary and expire originals when not dry run', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'e1', name: 'DECISION: A', fact: 'A', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'e2', name: 'DECISION: B', fact: 'B', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'e3', name: 'DECISION: C', fact: 'C', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: false,
+        minGroupSize: 3,
+      });
+
+      // Summary fact should be saved
+      assert.strictEqual(addFactCalls.length, 1);
+      assert.strictEqual(addFactCalls[0].groupId, 'group-1');
+      assert.ok(addFactCalls[0].fact.includes('[Compacted]'));
+      assert.ok(addFactCalls[0].tags.includes('type:compaction-summary'));
+      assert.ok(addFactCalls[0].tags.includes('compacted:decision'));
+
+      // All 3 originals should be expired
+      assert.strictEqual(expireFactCalls.length, 3);
+      assert.deepStrictEqual(
+        expireFactCalls.map(c => c.uuid).sort(),
+        ['e1', 'e2', 'e3']
+      );
+
+      assert.strictEqual(result.factsArchived, 3);
+      assert.strictEqual(result.summariesCreated, 1);
+    });
+
+    it('should handle multiple groups', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'f1', name: 'DECISION: A', fact: 'A', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'f2', name: 'DECISION: B', fact: 'B', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'f3', name: 'DECISION: C', fact: 'C', created_at: '2025-12-01T00:00:00.000Z' },
+        { uuid: 'f4', name: 'MILESTONE: X', fact: 'X', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'f5', name: 'MILESTONE: Y', fact: 'Y', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'f6', name: 'MILESTONE: Z', fact: 'Z', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      assert.strictEqual(result.groupsProcessed, 2);
+      assert.strictEqual(result.summariesCreated, 2);
+      assert.strictEqual(result.factsArchived, 6);
+
+      const topics = result.summaries.map(s => s.topic).sort();
+      assert.deepStrictEqual(topics, ['decision', 'milestone']);
+    });
+
+    it('should use default minGroupSize of 3', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'g1', name: 'DECISION: A', fact: 'A', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'g2', name: 'DECISION: B', fact: 'B', created_at: '2025-11-15T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        // No minGroupSize specified - should default to 3
+      });
+
+      assert.strictEqual(result.groupsProcessed, 0); // 2 < 3
+    });
+
+    it('should include date range in summary text', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'h1', name: 'DECISION: A', fact: 'Decision about A', created_at: '2025-10-15T10:00:00.000Z' },
+        { uuid: 'h2', name: 'DECISION: B', fact: 'Decision about B', created_at: '2025-11-20T12:00:00.000Z' },
+        { uuid: 'h3', name: 'DECISION: C', fact: 'Decision about C', created_at: '2025-12-25T14:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      const summaryText = result.summaries[0].summaryText;
+      assert.ok(summaryText.includes('2025-10-15'));
+      assert.ok(summaryText.includes('2025-12-25'));
+    });
+
+    it('should truncate long fact snippets', async () => {
+      const longText = 'A'.repeat(100);
+      const facts: IMemoryItem[] = [
+        { uuid: 'i1', name: 'DECISION: X', fact: longText, created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'i2', name: 'DECISION: Y', fact: 'Short', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'i3', name: 'DECISION: Z', fact: 'Also short', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      const summaryText = result.summaries[0].summaryText;
+      assert.ok(summaryText.includes('...'));
+      // Should not contain the full 100 chars
+      assert.ok(!summaryText.includes(longText));
+    });
+
+    it('should pass olderThan as until date to loadFactsDateOrdered', async () => {
+      const olderThan = new Date('2025-12-15');
+      const service = new CompactionService(createMockMemoryService([]));
+      await service.compact('group-1', { olderThan });
+
+      assert.strictEqual(loadFactsCalls.length, 1);
+      assert.strictEqual(loadFactsCalls[0].groupIds[0], 'group-1');
+      assert.strictEqual(loadFactsCalls[0].options?.until, olderThan);
+    });
+
+    it('should skip facts without uuid when archiving', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'j1', name: 'DECISION: A', fact: 'A', created_at: '2025-11-01T00:00:00.000Z' },
+        { name: 'DECISION: B', fact: 'B', created_at: '2025-11-15T00:00:00.000Z' }, // No uuid
+        { uuid: 'j3', name: 'DECISION: C', fact: 'C', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: false,
+        minGroupSize: 3,
+      });
+
+      // Only 2 facts have UUIDs
+      assert.strictEqual(result.summaries[0].archivedUuids.length, 2);
+      assert.strictEqual(expireFactCalls.length, 2);
+    });
+
+    it('should ignore type:compaction-summary tags for categorization', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'k1', name: 'fact one', fact: 'A', tags: ['type:compaction-summary'], created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'k2', name: 'fact two', fact: 'B', tags: ['type:compaction-summary'], created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'k3', name: 'fact three', fact: 'C', tags: ['type:compaction-summary'], created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.compact('group-1', {
+        olderThan: new Date('2026-01-01'),
+        dryRun: true,
+        minGroupSize: 3,
+      });
+
+      // Should fall to 'general' since compaction-summary is excluded
+      assert.strictEqual(result.summaries[0].topic, 'general');
+    });
+  });
+
+  describe('preview()', () => {
+    it('should be equivalent to compact with dryRun=true', async () => {
+      const facts: IMemoryItem[] = [
+        { uuid: 'p1', name: 'DECISION: A', fact: 'A', created_at: '2025-11-01T00:00:00.000Z' },
+        { uuid: 'p2', name: 'DECISION: B', fact: 'B', created_at: '2025-11-15T00:00:00.000Z' },
+        { uuid: 'p3', name: 'DECISION: C', fact: 'C', created_at: '2025-12-01T00:00:00.000Z' },
+      ];
+
+      const service = new CompactionService(createMockMemoryService(facts));
+      const result = await service.preview('group-1', {
+        olderThan: new Date('2026-01-01'),
+        minGroupSize: 3,
+      });
+
+      assert.strictEqual(result.groupsProcessed, 1);
+      assert.strictEqual(addFactCalls.length, 0);
+      assert.strictEqual(expireFactCalls.length, 0);
+    });
+  });
+});

--- a/tests/unit/src/lib/skills/shared/services/MemoryCliService.test.ts
+++ b/tests/unit/src/lib/skills/shared/services/MemoryCliService.test.ts
@@ -18,6 +18,7 @@ import type {
   IMemoryCleanupResult,
   IMemoryLinkResult,
   IMemoryLinksResult,
+  IMemoryCompactResult,
 } from '../../../../../../../src/lib/skills/shared/services/interfaces';
 
 const noopLogger: ILogger = {
@@ -108,6 +109,7 @@ describe('MemoryCliService', () => {
   let addCalls: Array<{ text: string; groupId: string; options: unknown }>;
   let linkCalls: Array<{ groupId: string; sourceUuid: string; targetUuid: string; relationType: string; metadata?: string }>;
   let linksCalls: Array<{ groupId: string; uuid: string; relationType?: string }>;
+  let compactCalls: Array<{ groupId: string; olderThan: Date; dryRun: boolean; minGroupSize: number }>;
 
   const memoryService: IMemoryService = {
     load: async (groupIds): Promise<IMemoryLoadResult> => ({
@@ -174,6 +176,25 @@ describe('MemoryCliService', () => {
         mode: 'neo4j',
       };
     },
+    compact: async (groupId, options): Promise<IMemoryCompactResult> => {
+      compactCalls.push({ groupId, ...options });
+      return {
+        status: 'ok',
+        action: 'compact',
+        group: groupId,
+        groupsProcessed: 1,
+        factsArchived: 5,
+        summariesCreated: 1,
+        summaries: [{
+          topic: 'decision',
+          factCount: 5,
+          summaryText: '[Compacted] Decision: 5 items',
+          archivedUuids: ['a', 'b', 'c', 'd', 'e'],
+        }],
+        dryRun: options.dryRun,
+        mode: 'neo4j',
+      };
+    },
   };
 
   function defaultArgs() {
@@ -193,6 +214,8 @@ describe('MemoryCliService', () => {
       dryRun: false,
       uuid: null,
       note: null,
+      before: null,
+      minGroup: 3,
     };
   }
 
@@ -202,6 +225,7 @@ describe('MemoryCliService', () => {
     addCalls = [];
     linkCalls = [];
     linksCalls = [];
+    compactCalls = [];
   });
 
   const cliService = createMemoryCliService({
@@ -497,11 +521,112 @@ describe('MemoryCliService', () => {
     });
   });
 
+  describe('compact command', () => {
+    it('should call memoryService.compact with parsed date and options', async () => {
+      const result = await cliService.run({
+        ...defaultArgs(),
+        command: 'compact',
+        before: '30d',
+        dryRun: false,
+        minGroup: 5,
+      });
+
+      assert.strictEqual(compactCalls.length, 1);
+      assert.strictEqual(compactCalls[0].groupId, 'test-group');
+      assert.strictEqual(compactCalls[0].dryRun, false);
+      assert.strictEqual(compactCalls[0].minGroupSize, 5);
+      assert.ok(compactCalls[0].olderThan instanceof Date);
+      assert.strictEqual(result.action, 'compact');
+    });
+
+    it('should pass dryRun=true when set', async () => {
+      const result = await cliService.run({
+        ...defaultArgs(),
+        command: 'compact',
+        before: '30d',
+        dryRun: true,
+      });
+
+      assert.strictEqual(compactCalls[0].dryRun, true);
+      const compactResult = result as IMemoryCompactResult;
+      assert.strictEqual(compactResult.dryRun, true);
+    });
+
+    it('should use default minGroup of 3', async () => {
+      await cliService.run({
+        ...defaultArgs(),
+        command: 'compact',
+        before: '7d',
+      });
+
+      assert.strictEqual(compactCalls[0].minGroupSize, 3);
+    });
+
+    it('should use explicit group if provided', async () => {
+      await cliService.run({
+        ...defaultArgs(),
+        command: 'compact',
+        before: '30d',
+        explicitGroup: 'custom-group',
+      });
+
+      assert.strictEqual(compactCalls[0].groupId, 'custom-group');
+    });
+
+    it('should throw if --before is not provided', async () => {
+      await assert.rejects(
+        () => cliService.run({ ...defaultArgs(), command: 'compact' }),
+        { message: /compact requires --before/ }
+      );
+    });
+
+    it('should throw for invalid --before date', async () => {
+      await assert.rejects(
+        () => cliService.run({
+          ...defaultArgs(),
+          command: 'compact',
+          before: 'not-a-date',
+        }),
+        { message: /Invalid --before date/ }
+      );
+    });
+
+    it('should parse ISO date for --before', async () => {
+      await cliService.run({
+        ...defaultArgs(),
+        command: 'compact',
+        before: '2025-12-01',
+      });
+
+      assert.strictEqual(compactCalls.length, 1);
+      const olderThan = compactCalls[0].olderThan;
+      // Should be Dec 1 2025
+      assert.strictEqual(olderThan.getFullYear(), 2025);
+      assert.strictEqual(olderThan.getMonth(), 11); // 0-indexed
+      assert.strictEqual(olderThan.getDate(), 1);
+    });
+
+    it('should parse relative date for --before', async () => {
+      await cliService.run({
+        ...defaultArgs(),
+        command: 'compact',
+        before: 'today',
+      });
+
+      assert.strictEqual(compactCalls.length, 1);
+      const olderThan = compactCalls[0].olderThan;
+      const today = new Date();
+      assert.strictEqual(olderThan.getFullYear(), today.getFullYear());
+      assert.strictEqual(olderThan.getMonth(), today.getMonth());
+      assert.strictEqual(olderThan.getDate(), today.getDate());
+    });
+  });
+
   describe('invalid command', () => {
     it('should throw for unknown commands', async () => {
       await assert.rejects(
         () => cliService.run({ ...defaultArgs(), command: 'unknown' }),
-        { message: /command must be add\|load\|expire\|cleanup\|link\|links/ }
+        { message: /command must be add\|load\|expire\|cleanup\|link\|links\|compact/ }
       );
     });
   });


### PR DESCRIPTION
## Summary

- Add `CompactionService` that groups old facts by topic category, creates template-based summaries, and archives (expires) the originals
- Domain types: `ICompactionService`, `ICompactionResult`, `ICompactionSummary`, `ICompactionOptions`
- Infrastructure implementation with DI container registration
- Skill-level `compact()` method using Neo4j Cypher with tag retrieval
- CLI: `lisa memory compact --before <date> [--dry-run] [--min-group N]`
- 23 new tests (15 CompactionService + 8 CLI compact command tests)

## Test plan

- [x] CompactionService tests: empty facts, group filtering, name prefix grouping, tag-based grouping, dry run, real compaction, multiple groups, date ranges, snippet truncation, UUID handling
- [x] MemoryCliService tests: date parsing, dry-run flag, min-group, explicit group, missing --before, invalid date, ISO date, relative date
- [x] All 1123 tests pass
- [x] Lint clean
- [x] TypeScript compiles
- [x] Build succeeds

Closes #153
Part of Epic #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)